### PR TITLE
Fix precision handling for loss recording

### DIFF
--- a/app/Traits/HasLosses.php
+++ b/app/Traits/HasLosses.php
@@ -39,7 +39,7 @@ trait HasLosses
         $pivot = $locationEntity->pivot;
         $available = (float) $pivot->quantity;
 
-        $newQuantity = round($available - $quantity, 2);
+        $newQuantity = round($available - $quantity, 3);
 
         if ($newQuantity < 0) {
             throw new \RuntimeException('Insufficient stock at location');

--- a/app/Traits/HasLosses.php
+++ b/app/Traits/HasLosses.php
@@ -39,11 +39,11 @@ trait HasLosses
         $pivot = $locationEntity->pivot;
         $available = (float) $pivot->quantity;
 
-        if ($available < $quantity) {
+        $newQuantity = round($available - $quantity, 2);
+
+        if ($newQuantity < 0) {
             throw new \RuntimeException('Insufficient stock at location');
         }
-
-        $newQuantity = round($available - $quantity, 2);
 
         // Mettre à jour la quantité à l'emplacement
         $this->locations()->updateExistingPivot($location->id, [

--- a/tests/Feature/LossTrackingTest.php
+++ b/tests/Feature/LossTrackingTest.php
@@ -125,6 +125,31 @@ class LossTrackingTest extends TestCase
     }
 
     /**
+     * Enregistre correctement une perte avec des quantités décimales proches.
+     */
+    public function test_recording_loss_with_decimal_precision(): void
+    {
+        $this->ingredient->locations()->updateExistingPivot($this->location->id, ['quantity' => 0.68]);
+        StockMovement::query()->delete();
+
+        $response = $this->postJson('/api/losses', [
+            'trackable_type' => 'ingredient',
+            'trackable_id' => $this->ingredient->id,
+            'location_id' => $this->location->id,
+            'quantity' => 0.67,
+            'reason' => 'Test',
+        ]);
+
+        $response->assertStatus(201);
+
+        $this->assertDatabaseHas('ingredient_location', [
+            'ingredient_id' => $this->ingredient->id,
+            'location_id' => $this->location->id,
+            'quantity' => 0.01,
+        ]);
+    }
+
+    /**
      * Empêche l'enregistrement d'une perte si le stock est insuffisant.
      */
     public function test_recording_loss_with_insufficient_stock_returns_error(): void

--- a/tests/Feature/LossTrackingTest.php
+++ b/tests/Feature/LossTrackingTest.php
@@ -150,6 +150,27 @@ class LossTrackingTest extends TestCase
     }
 
     /**
+     * Permet de retirer une quantité infime égale au stock disponible.
+     */
+    public function test_recording_loss_with_thousandth_precision(): void
+    {
+        $this->ingredient->locations()->updateExistingPivot($this->location->id, ['quantity' => 0.001]);
+
+        $loss = $this->ingredient->recordLoss($this->location, 0.001, 'Test');
+
+        $this->assertDatabaseHas('losses', [
+            'id' => $loss->id,
+            'quantity' => 0.001,
+        ]);
+
+        $this->assertDatabaseHas('ingredient_location', [
+            'ingredient_id' => $this->ingredient->id,
+            'location_id' => $this->location->id,
+            'quantity' => 0.0,
+        ]);
+    }
+
+    /**
      * Empêche l'enregistrement d'une perte si le stock est insuffisant.
      */
     public function test_recording_loss_with_insufficient_stock_returns_error(): void


### PR DESCRIPTION
## Summary
- prevent false insufficient stock errors by rounding and verifying remaining quantity
- add regression test for near-equal decimal losses

## Testing
- `composer test` (fails: file_get_contents(/workspace/KHP-back/.env): Failed to open stream: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68b2215154e8832d99b452713ac7eeb9