### PR TITLE
Track ingredient expiration in perishable table

### DIFF
--- a/app/Console/Commands/ExpirePerishables.php
+++ b/app/Console/Commands/ExpirePerishables.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Perishable;
+use App\Models\Loss;
+use App\Models\Ingredient;
+use App\Services\PerishableService;
+
+class ExpirePerishables extends Command
+{
+    protected $signature = 'perishables:expire';
+
+    protected $description = 'Convert expired perishable stock into losses';
+
+    public function handle(PerishableService $service): int
+    {
+        $perishables = Perishable::with(['ingredient.category.locationTypes', 'location'])
+            ->get()
+            ->filter(fn ($p) => $service->expiration($p)->isPast());
+
+        foreach ($perishables as $perishable) {
+            Loss::create([
+                'lossable_id' => $perishable->ingredient_id,
+                'lossable_type' => Ingredient::class,
+                'location_id' => $perishable->location_id,
+                'company_id' => $perishable->company_id,
+                'user_id' => null,
+                'quantity' => $perishable->quantity,
+                'reason' => 'expired',
+            ]);
+
+            $perishable->delete();
+        }
+
+        return 0;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Console;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+
+class Kernel extends ConsoleKernel
+{
+    protected $commands = [
+        \App\Console\Commands\ExpirePerishables::class,
+    ];
+
+    protected function schedule(Schedule $schedule): void
+    {
+        $schedule->command('perishables:expire')->hourly();
+    }
+
+    protected function commands(): void
+    {
+        $this->load(__DIR__.'/Commands');
+
+        require base_path('routes/console.php');
+    }
+}

--- a/app/GraphQL/Queries/NonPerishableIngredientsQuery.php
+++ b/app/GraphQL/Queries/NonPerishableIngredientsQuery.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\GraphQL\Queries;
+
+use App\Models\Ingredient;
+
+class NonPerishableIngredientsQuery
+{
+    public function resolve()
+    {
+        $companyId = auth()->user()->company_id;
+
+        return Ingredient::with(['category.locationTypes', 'locations'])
+            ->where('company_id', $companyId)
+            ->get()
+            ->filter(function ($ingredient) {
+                return $ingredient->locations->every(function ($location) use ($ingredient) {
+                    $shelfLife = $ingredient->category->locationTypes
+                        ->firstWhere('id', $location->location_type_id)?->pivot->shelf_life_hours;
+
+                    return ! $shelfLife;
+                });
+            });
+    }
+}

--- a/app/GraphQL/Queries/PerishableQuery.php
+++ b/app/GraphQL/Queries/PerishableQuery.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\GraphQL\Queries;
+
+use App\Models\Perishable;
+use App\Services\PerishableService;
+use Illuminate\Support\Carbon;
+
+class PerishableQuery
+{
+    public function resolve(mixed $_, array $args, PerishableService $service)
+    {
+        $filter = $args['filter'] ?? 'ACTIVE';
+
+        if ($filter === 'EXPIRED') {
+            return Perishable::onlyTrashed()->forCompany()->get();
+        }
+
+        $perishables = Perishable::with(['ingredient.category.locationTypes', 'location'])
+            ->forCompany()
+            ->get();
+
+        if ($filter === 'SOON') {
+            $threshold = Carbon::now()->addHours(48);
+            return $perishables->filter(fn ($p) => $service->expiration($p)->between(now(), $threshold));
+        }
+
+        return $perishables->filter(fn ($p) => $service->expiration($p)->isFuture());
+    }
+}

--- a/app/Http/Controllers/PreparationController.php
+++ b/app/Http/Controllers/PreparationController.php
@@ -8,6 +8,7 @@ use App\Models\Location;
 use App\Models\LocationType;
 use App\Models\Preparation;
 use App\Models\PreparationEntity;
+use App\Services\PerishableService;
 use App\Services\ImageService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -307,7 +308,7 @@ class PreparationController extends Controller
      *
      * @param  int  $id
      */
-    public function prepare(Request $request, $id): JsonResponse
+    public function prepare(Request $request, $id, PerishableService $perishableService): JsonResponse
     {
         $user = $request->user();
 
@@ -408,6 +409,10 @@ class PreparationController extends Controller
                         $source['location_id'],
                         ['quantity' => $pivot->quantity - $source['quantity']]
                     );
+
+                    if ($entity instanceof Ingredient) {
+                        $perishableService->remove($entity->id, $source['location_id'], $user->company_id, $source['quantity']);
+                    }
                 }
             }
 
@@ -483,7 +488,7 @@ class PreparationController extends Controller
 
         return response()->json([
             'message' => 'Quantité de la préparation mise à jour avec succès',
-            'preparation' => $preparation->load('entities.entity', 'locations', 'categories'),
+            'preparation' => $preparation->load('entities.entity', 'locations', 'category'),
         ], 200);
     }
 }

--- a/app/Models/Perishable.php
+++ b/app/Models/Perishable.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
+use App\Services\PerishableService;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Perishable extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'ingredient_id',
+        'location_id',
+        'company_id',
+        'quantity',
+    ];
+
+    public function ingredient(): BelongsTo
+    {
+        return $this->belongsTo(Ingredient::class);
+    }
+
+    public function location(): BelongsTo
+    {
+        return $this->belongsTo(Location::class);
+    }
+
+    public function company(): BelongsTo
+    {
+        return $this->belongsTo(Company::class);
+    }
+
+    public function scopeForCompany(Builder $query): Builder
+    {
+        return $query->where('company_id', auth()->user()->company_id);
+    }
+
+    public function getExpirationAtAttribute(): Carbon
+    {
+        return app(PerishableService::class)->expiration($this);
+    }
+}
+

--- a/app/Services/PerishableService.php
+++ b/app/Services/PerishableService.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Ingredient;
+use App\Models\Location;
+use App\Models\Perishable;
+use Illuminate\Support\Carbon;
+
+class PerishableService
+{
+    public function add(int $ingredientId, int $locationId, int $companyId, float $quantity): ?Perishable
+    {
+        $ingredient = Ingredient::with('category.locationTypes')->find($ingredientId);
+        $location = Location::find($locationId);
+
+        if (! $ingredient || ! $location) {
+            return null;
+        }
+
+        $shelfLife = $ingredient->category
+            ->locationTypes()
+            ->where('location_type_id', $location->location_type_id)
+            ->first()
+            ?->pivot->shelf_life_hours;
+
+        if (! $shelfLife) {
+            return null;
+        }
+
+        return Perishable::create([
+            'ingredient_id' => $ingredientId,
+            'location_id' => $locationId,
+            'company_id' => $companyId,
+            'quantity' => $quantity,
+        ]);
+    }
+
+    public function remove(int $ingredientId, int $locationId, int $companyId, float $quantity): void
+    {
+        $perishables = Perishable::with(['ingredient.category.locationTypes', 'location'])
+            ->where('ingredient_id', $ingredientId)
+            ->where('location_id', $locationId)
+            ->where('company_id', $companyId)
+            ->get()
+            ->filter(fn ($p) => $this->expiration($p)->isFuture())
+            ->sortBy(fn ($p) => $this->expiration($p));
+
+        foreach ($perishables as $perishable) {
+            if ($quantity <= 0) {
+                break;
+            }
+
+            $remove = min($perishable->quantity, $quantity);
+            $perishable->quantity -= $remove;
+            $quantity -= $remove;
+
+            if ($perishable->quantity <= 0) {
+                $perishable->delete();
+            } else {
+                $perishable->save();
+            }
+        }
+    }
+
+    public function expiration(Perishable $perishable): Carbon
+    {
+        $locationTypeId = $perishable->location->location_type_id;
+        $shelfLife = $perishable->ingredient->category
+            ->locationTypes()
+            ->where('location_type_id', $locationTypeId)
+            ->first()
+            ?->pivot->shelf_life_hours;
+
+        if (! $shelfLife) {
+            return Carbon::create(9999, 12, 31, 23, 59, 59);
+        }
+
+        return $perishable->created_at->copy()->addHours($shelfLife);
+    }
+}
+

--- a/database/migrations/2025_08_30_000014_create_perishables_table.php
+++ b/database/migrations/2025_08_30_000014_create_perishables_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('perishables', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('ingredient_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('location_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('company_id')->constrained()->cascadeOnDelete();
+            $table->decimal('quantity', 8, 2);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('perishables');
+    }
+};

--- a/graphql/models/perishable.graphql
+++ b/graphql/models/perishable.graphql
@@ -1,0 +1,22 @@
+enum PerishableFilter {
+    ACTIVE
+    SOON
+    EXPIRED
+}
+
+type Perishable {
+    id: ID!
+    ingredient: Ingredient! @belongsTo
+    location: Location! @belongsTo
+    quantity: Float!
+    expiration_at: DateTime!
+    created_at: DateTime!
+    updated_at: DateTime!
+}
+
+extend type Query @guard {
+    perishables(filter: PerishableFilter = ACTIVE): [Perishable!]!
+        @field(resolver: "App\\GraphQL\\Queries\\PerishableQuery@resolve")
+    nonPerishableIngredients: [Ingredient!]!
+        @field(resolver: "App\\GraphQL\\Queries\\NonPerishableIngredientsQuery@resolve")
+}

--- a/tests/Feature/PreparationControllerTest.php
+++ b/tests/Feature/PreparationControllerTest.php
@@ -9,6 +9,7 @@ use App\Models\Location;
 use App\Models\LocationType;
 use App\Models\Preparation;
 use App\Models\PreparationEntity;
+use App\Models\Perishable;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
@@ -803,6 +804,58 @@ class PreparationControllerTest extends TestCase
 
         // Quantité destination
         $this->assertDatabaseHas('location_preparation', ['preparation_id' => $preparation->id, 'location_id' => $location2->id, 'quantity' => 2.5]);
+    }
+
+    public function test_prepare_removes_perime_quantities(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+
+        $ingredient = Ingredient::factory()->create(['company_id' => $company->id]);
+        $source = Location::factory()->create(['company_id' => $company->id]);
+        $destination = Location::factory()->create(['company_id' => $company->id]);
+
+        $ingredient->locations()->updateExistingPivot($source->id, ['quantity' => 5]);
+
+        Perishable::create([
+            'ingredient_id' => $ingredient->id,
+            'location_id' => $source->id,
+            'company_id' => $company->id,
+            'quantity' => 5,
+        ]);
+
+        $preparation = Preparation::factory()->create(['company_id' => $company->id]);
+        PreparationEntity::create([
+            'preparation_id' => $preparation->id,
+            'entity_id' => $ingredient->id,
+            'entity_type' => Ingredient::class,
+        ]);
+
+        $payload = [
+            'quantity' => 1,
+            'location_id' => $destination->id,
+            'components' => [
+                [
+                    'entity_id' => $ingredient->id,
+                    'entity_type' => 'ingredient',
+                    'quantity' => 2,
+                    'sources' => [
+                        ['location_id' => $source->id, 'quantity' => 2],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->actingAs($user)
+            ->postJson("/api/preparations/{$preparation->id}/prepare", $payload)
+            ->assertStatus(200);
+
+        $this->assertDatabaseHas('perishables', [
+            'ingredient_id' => $ingredient->id,
+            'location_id' => $source->id,
+            'company_id' => $company->id,
+            'quantity' => 3,
+        ]);
     }
 
     /** Scénario : préparation avec plusieurs emplacements sources. */

--- a/tests/Unit/PerishableTest.php
+++ b/tests/Unit/PerishableTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Category;
+use App\Models\Company;
+use App\Models\Ingredient;
+use App\Models\Location;
+use App\Models\LocationType;
+use App\Models\Perishable;
+use App\Models\Loss;
+use App\Models\User;
+use App\Services\PerishableService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PerishableTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_remove_quantity_skips_expired_and_prioritizes_earliest_expiration(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+        $this->actingAs($user);
+
+        $category = Category::factory()->create(['company_id' => $company->id]);
+        $ingredient = Ingredient::factory()->create([
+            'company_id' => $company->id,
+            'category_id' => $category->id,
+        ]);
+        $locationType = LocationType::factory()->create();
+        $location = Location::factory()->create([
+            'company_id' => $company->id,
+            'location_type_id' => $locationType->id,
+        ]);
+
+        $category->locationTypes()->attach($locationType->id, ['shelf_life_hours' => 24]);
+
+        $p1 = Perishable::create([
+            'ingredient_id' => $ingredient->id,
+            'location_id' => $location->id,
+            'company_id' => $company->id,
+            'quantity' => 2,
+        ]);
+        $p1->forceFill(['created_at' => now()->subDays(3), 'updated_at' => now()->subDays(3)])->save();
+
+        $p2 = Perishable::create([
+            'ingredient_id' => $ingredient->id,
+            'location_id' => $location->id,
+            'company_id' => $company->id,
+            'quantity' => 2,
+        ]);
+        $p2->forceFill(['created_at' => now()->subHours(10), 'updated_at' => now()->subHours(10)])->save();
+
+        Perishable::create([
+            'ingredient_id' => $ingredient->id,
+            'location_id' => $location->id,
+            'company_id' => $company->id,
+            'quantity' => 2,
+        ]);
+
+        $service = new PerishableService();
+        $service->remove($ingredient->id, $location->id, $company->id, 3);
+
+        $this->assertSame(2, Perishable::count());
+        $this->assertDatabaseHas('perishables', [
+            'ingredient_id' => $ingredient->id,
+            'location_id' => $location->id,
+            'company_id' => $company->id,
+            'quantity' => 2,
+        ]);
+        $this->assertDatabaseHas('perishables', [
+            'ingredient_id' => $ingredient->id,
+            'location_id' => $location->id,
+            'company_id' => $company->id,
+            'quantity' => 1,
+        ]);
+    }
+
+    public function test_expire_command_creates_loss_and_soft_deletes(): void
+    {
+        $company = Company::factory()->create();
+        $category = Category::factory()->create(['company_id' => $company->id]);
+        $ingredient = Ingredient::factory()->create([
+            'company_id' => $company->id,
+            'category_id' => $category->id,
+        ]);
+        $locationType = LocationType::factory()->create();
+        $location = Location::factory()->create([
+            'company_id' => $company->id,
+            'location_type_id' => $locationType->id,
+        ]);
+
+        $category->locationTypes()->attach($locationType->id, ['shelf_life_hours' => 1]);
+
+        $perishable = Perishable::create([
+            'ingredient_id' => $ingredient->id,
+            'location_id' => $location->id,
+            'company_id' => $company->id,
+            'quantity' => 4,
+        ]);
+        $perishable->forceFill(['created_at' => now()->subHours(2), 'updated_at' => now()->subHours(2)])->save();
+
+        $this->artisan('perishables:expire')->assertExitCode(0);
+
+        $this->assertSoftDeleted('perishables', ['id' => $perishable->id]);
+        $this->assertDatabaseHas('losses', [
+            'lossable_id' => $ingredient->id,
+            'lossable_type' => Ingredient::class,
+            'location_id' => $location->id,
+            'company_id' => $company->id,
+            'quantity' => 4,
+            'reason' => 'expired',
+        ]);
+    }
+}
+


### PR DESCRIPTION
## Summary
- avoid perishable entries when shelf life is missing and expose non-perishable ingredients via GraphQL
- schedule hourly command to convert expired stock into losses and soft-delete perishable rows
- allow GraphQL filtering for upcoming and expired batches

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68b2220c90d8832dbd91b9152d72b161