### PR TITLE
Split perishable seeding into dedicated seeder

### DIFF
--- a/app/Console/Commands/ExpirePerishables.php
+++ b/app/Console/Commands/ExpirePerishables.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Perishable;
+use App\Models\Loss;
+use App\Models\Ingredient;
+use App\Services\PerishableService;
+
+class ExpirePerishables extends Command
+{
+    protected $signature = 'perishables:expire';
+
+    protected $description = 'Convert expired perishable stock into losses';
+
+    public function handle(PerishableService $service): int
+    {
+        $perishables = Perishable::with(['ingredient.category.locationTypes', 'location'])
+            ->get()
+            ->filter(fn ($p) => $service->expiration($p)->isPast());
+
+        foreach ($perishables as $perishable) {
+            Loss::create([
+                'lossable_id' => $perishable->ingredient_id,
+                'lossable_type' => Ingredient::class,
+                'location_id' => $perishable->location_id,
+                'company_id' => $perishable->company_id,
+                'user_id' => null,
+                'quantity' => $perishable->quantity,
+                'reason' => 'expired',
+            ]);
+
+            $perishable->delete();
+        }
+
+        return 0;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Console;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+
+class Kernel extends ConsoleKernel
+{
+    protected $commands = [
+        \App\Console\Commands\ExpirePerishables::class,
+    ];
+
+    protected function schedule(Schedule $schedule): void
+    {
+        $schedule->command('perishables:expire')->hourly();
+    }
+
+    protected function commands(): void
+    {
+        $this->load(__DIR__.'/Commands');
+
+        require base_path('routes/console.php');
+    }
+}

--- a/app/GraphQL/Queries/NonPerishableIngredientsQuery.php
+++ b/app/GraphQL/Queries/NonPerishableIngredientsQuery.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\GraphQL\Queries;
+
+use App\Models\Ingredient;
+
+class NonPerishableIngredientsQuery
+{
+    public function resolve()
+    {
+        $companyId = auth()->user()->company_id;
+
+        return Ingredient::with(['category.locationTypes', 'locations'])
+            ->where('company_id', $companyId)
+            ->get()
+            ->filter(function ($ingredient) {
+                return $ingredient->locations->every(function ($location) use ($ingredient) {
+                    $shelfLife = $ingredient->category->locationTypes
+                        ->firstWhere('id', $location->location_type_id)?->pivot->shelf_life_hours;
+
+                    return ! $shelfLife;
+                });
+            });
+    }
+}

--- a/app/GraphQL/Queries/PerishableQuery.php
+++ b/app/GraphQL/Queries/PerishableQuery.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\GraphQL\Queries;
+
+use App\Models\Perishable;
+use App\Services\PerishableService;
+use GraphQL\Type\Definition\ResolveInfo;
+use Illuminate\Support\Carbon;
+use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
+
+class PerishableQuery
+{
+    public function __construct(private PerishableService $service)
+    {
+    }
+
+    public function resolve(mixed $_, array $args, GraphQLContext $context, ResolveInfo $info)
+    {
+        $filter = $args['filter'] ?? 'ACTIVE';
+
+        if ($filter === 'EXPIRED') {
+            return Perishable::onlyTrashed()->forCompany()->get();
+        }
+
+        $perishables = Perishable::with(['ingredient.category.locationTypes', 'location'])
+            ->forCompany()
+            ->get();
+
+        if ($filter === 'SOON') {
+            $threshold = Carbon::now()->addHours(48);
+            return $perishables->filter(fn ($p) => $this->service->expiration($p)->between(now(), $threshold));
+        }
+
+        return $perishables->filter(fn ($p) => $this->service->expiration($p)->isFuture());
+    }
+}

--- a/app/Http/Controllers/IngredientController.php
+++ b/app/Http/Controllers/IngredientController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Enums\MeasurementUnit;
 use App\Models\Ingredient;
 use App\Models\Location;
+use App\Services\PerishableService;
 use App\Services\ImageService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -14,7 +15,12 @@ use Illuminate\Validation\ValidationException;
 class IngredientController extends Controller
 {
     /**
-     * Store a newly created resource in storage.
+     * Cas métier : Création d'un nouvel ingrédient
+     *
+     * Use cases :
+     * - Ajouter un ingrédient au catalogue de l'entreprise
+     * - Référencer un produit avec sa catégorie et son unité
+     * - Initialiser des stocks sur un ou plusieurs emplacements
      */
     public function store(Request $request, ImageService $imageService)
     {
@@ -93,7 +99,12 @@ class IngredientController extends Controller
     }
 
     /**
-     * Update the specified resource in storage.
+     * Cas métier : Mise à jour d'un ingrédient existant
+     *
+     * Use cases :
+     * - Modifier le nom ou l'unité d'un ingrédient
+     * - Changer l'image associée
+     * - Recatégoriser un produit
      */
     public function update(Request $request, Ingredient $ingredient, ImageService $imageService)
     {
@@ -182,7 +193,11 @@ class IngredientController extends Controller
     }
 
     /**
-     * Remove the specified resource from storage.
+     * Cas métier : Suppression d'un ingrédient
+     *
+     * Use cases :
+     * - Retirer un ingrédient obsolète du catalogue
+     * - Corriger une création erronée
      */
     public function destroy(Ingredient $ingredient)
     {
@@ -200,9 +215,14 @@ class IngredientController extends Controller
     }
 
     /**
-     * Adjust the quantity of an ingredient for a specific location.
+     * Cas métier : Ajustement de stock d'un ingrédient sur un emplacement
+     *
+     * Use cases :
+     * - Réception de nouvelle marchandise
+     * - Correction manuelle du stock
+     * - Consommation ou retrait d'ingrédients
      */
-    public function adjustQuantity(Request $request, Ingredient $ingredient): JsonResponse
+    public function adjustQuantity(Request $request, Ingredient $ingredient, PerishableService $perishableService): JsonResponse
     {
         $user = $request->user();
 
@@ -235,9 +255,15 @@ class IngredientController extends Controller
             $location->id => ['quantity' => $newQuantity],
         ]);
 
+        if ($adjustment > 0) {
+            $perishableService->add($ingredient->id, $location->id, $user->company_id, $adjustment);
+        } elseif ($adjustment < 0) {
+            $perishableService->remove($ingredient->id, $location->id, $user->company_id, abs($adjustment));
+        }
+
         return response()->json([
             'message' => 'Ingredient quantity updated successfully',
-            'ingredient' => $ingredient->load('locations', 'categories'),
+            'ingredient' => $ingredient->load('locations', 'category'),
         ], 200);
     }
 }

--- a/app/Http/Controllers/PreparationController.php
+++ b/app/Http/Controllers/PreparationController.php
@@ -8,6 +8,7 @@ use App\Models\Location;
 use App\Models\LocationType;
 use App\Models\Preparation;
 use App\Models\PreparationEntity;
+use App\Services\PerishableService;
 use App\Services\ImageService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -26,23 +27,17 @@ use Illuminate\Validation\ValidationException;
 class PreparationController extends Controller
 {
     /**
-     * Crée une nouvelle préparation.
+     * Cas métier : Création d'une préparation
      *
-     * Règles métier pour la méthode store() :
-     * - 'name' : obligatoire, chaîne de caractères, max 255, unique par société.
-     * - 'unit' : obligatoire, chaîne parmi MeasurementUnit::values().
-     * - 'entities' : obligatoire, tableau, au moins 2 éléments.
-     *     • entities.*.id : entier requis.
-     *     • entities.*.type : doit être 'ingredient' ou 'preparation'.
-     * - 'category_id' : obligatoire, identifiant de catégorie existante.
-     * - 'image' / 'image_url' : optionnels, mais mutuellement exclusifs.
-     *   • si 'image' fourni => upload S3 via ImageService
-     *   • si 'image_url' fourni => téléchargement + stockage S3 via ImageService
-     * - La préparation est automatiquement liée à la société de l'utilisateur.
-     * - Pour chaque entité fournie, un enregistrement PreparationEntity est créé.
+     * Use cases :
+     * - Définir une nouvelle recette composée d'ingrédients et/ou de sous-préparations
+     * - Associer une image illustrant la préparation
+     * - Catégoriser la préparation pour la gestion des stocks
      *
-     * Succès : HTTP 201 + JSON [ 'message', 'preparation' avec entités chargées ].
-     * Échec : HTTP 422 + détails des erreurs de validation.
+     * Règles métier :
+     * - 'name' unique par entreprise
+     * - Au moins deux entités doivent composer la préparation
+     * - Image et image_url sont mutuellement exclusifs
      *
      * @throws \Illuminate\Validation\ValidationException
      */
@@ -120,30 +115,14 @@ class PreparationController extends Controller
     }
 
     /**
-     * Met à jour une préparation existante.
+     * Cas métier : Mise à jour d'une préparation
      *
-     * On attend maintenant deux tableaux optionnels et un tableau de quantités :
-     * - 'entities_to_add'    : array d'entités à créer si elles n'existent pas encore
-     * - 'entities_to_remove' : array d'entités à supprimer
-     * - 'category_id'      : identifiant de catégorie à associer (remplace l'existante)
-     * - 'quantities'         : array de quantités par emplacement
-     * - 'image' / 'image_url': optionnels et mutuellement exclusifs (MAJ de l'illustration)
+     * Use cases :
+     * - Ajouter ou retirer des composants de la recette
+     * - Ajuster les quantités disponibles par emplacement
+     * - Modifier l'image ou la catégorie associée
      *
-     * Règles métier pour update() :
-     * - La préparation doit appartenir à la même société que l'utilisateur (404 sinon).
-     * - 'name' et 'unit' restent facultatifs et validés comme avant.
-     * - 'entities_to_add' et 'entities_to_remove' sont chacun :
-     *     • facultatifs
-     *     • tableau d'objets { id:int, type:'ingredient'|'preparation' }
-     * - 'quantities' est un tableau d'objets { location_id:int, quantity:float }
-     * - Si on fournit 'entities_to_remove', on supprime **seulement** ces liens.
-     * - Si on fournit 'entities_to_add', on crée **seulement** les nouveaux liens qui n'existent pas.
-     * - Si on fournit 'quantities', on met à jour ou ajoute les quantités pour les emplacements spécifiés.
-     *
-     * Succès : HTTP 200 + JSON { message, preparation (avec entités chargées) }.
-     * Échec : HTTP 422 si validation, HTTP 404 si accès non autorisé.
-     *
-     * @param  int  $id
+     * @param int $id
      */
     public function update(Request $request, $id, ImageService $imageService): JsonResponse
     {
@@ -270,16 +249,13 @@ class PreparationController extends Controller
     }
 
     /**
-     * Supprime une préparation.
+     * Cas métier : Suppression d'une préparation
      *
-     * Règles métier pour destroy() :
-     * - La préparation doit appartenir à la même société que l'utilisateur (404 sinon).
-     * - La suppression est en cascade, donc toutes les entités liées sont également supprimées.
+     * Use cases :
+     * - Retirer une recette qui n'est plus utilisée
+     * - Corriger une préparation créée par erreur
      *
-     * Succès : HTTP 204 sans contenu.
-     * Échec : HTTP 404 si la préparation n'existe pas ou n'appartient pas à la société de l'utilisateur.
-     *
-     * @param  int  $id
+     * @param int $id
      */
     public function destroy(Request $request, $id): JsonResponse
     {
@@ -295,19 +271,19 @@ class PreparationController extends Controller
     }
 
     /**
-     * Prépare une quantité d'une préparation en utilisant ses composants.
+     * Cas métier : Réalisation d'une préparation
      *
-     * Cette fonction:
-     * 1. Retire les quantités spécifiées des composants (ingrédients/préparations)
-     * 2. Ajoute la quantité produite à l'emplacement de destination
+     * Use cases :
+     * - Transformer des ingrédients en préparation finale
+     * - Déduire automatiquement les stocks utilisés
+     * - Augmenter la quantité disponible de la préparation produite
      *
-     * Pour chaque composant, on peut prélever des quantités depuis plusieurs emplacements.
-     * Si la quantité disponible est insuffisante, l'opération échoue.
-     * Les emplacements de type congélateur ne peuvent pas être utilisés.
+     * Les sources peuvent provenir de plusieurs emplacements et doivent respecter
+     * la disponibilité des stocks.
      *
-     * @param  int  $id
+     * @param int $id
      */
-    public function prepare(Request $request, $id): JsonResponse
+    public function prepare(Request $request, $id, PerishableService $perishableService): JsonResponse
     {
         $user = $request->user();
 
@@ -408,6 +384,10 @@ class PreparationController extends Controller
                         $source['location_id'],
                         ['quantity' => $pivot->quantity - $source['quantity']]
                     );
+
+                    if ($entity instanceof Ingredient) {
+                        $perishableService->remove($entity->id, $source['location_id'], $user->company_id, $source['quantity']);
+                    }
                 }
             }
 
@@ -448,7 +428,11 @@ class PreparationController extends Controller
     }
 
     /**
-     * Ajuste la quantité d'une préparation pour un emplacement donné.
+     * Cas métier : Ajustement du stock d'une préparation
+     *
+     * Use cases :
+     * - Correction manuelle après inventaire
+     * - Production ou retrait hors processus standard
      */
     public function adjustQuantity(Request $request, $id): JsonResponse
     {
@@ -483,7 +467,7 @@ class PreparationController extends Controller
 
         return response()->json([
             'message' => 'Quantité de la préparation mise à jour avec succès',
-            'preparation' => $preparation->load('entities.entity', 'locations', 'categories'),
+            'preparation' => $preparation->load('entities.entity', 'locations', 'category'),
         ], 200);
     }
 }

--- a/app/Models/Perishable.php
+++ b/app/Models/Perishable.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
+use App\Services\PerishableService;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Perishable extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'ingredient_id',
+        'location_id',
+        'company_id',
+        'quantity',
+    ];
+
+    public function ingredient(): BelongsTo
+    {
+        return $this->belongsTo(Ingredient::class);
+    }
+
+    public function location(): BelongsTo
+    {
+        return $this->belongsTo(Location::class);
+    }
+
+    public function company(): BelongsTo
+    {
+        return $this->belongsTo(Company::class);
+    }
+
+    public function scopeForCompany(Builder $query): Builder
+    {
+        return $query->where('company_id', auth()->user()->company_id);
+    }
+
+    public function getExpirationAtAttribute(): Carbon
+    {
+        return app(PerishableService::class)->expiration($this);
+    }
+}
+

--- a/app/Services/PerishableService.php
+++ b/app/Services/PerishableService.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Ingredient;
+use App\Models\Location;
+use App\Models\Perishable;
+use Illuminate\Support\Carbon;
+
+class PerishableService
+{
+    public function add(int $ingredientId, int $locationId, int $companyId, float $quantity): ?Perishable
+    {
+        $ingredient = Ingredient::with('category.locationTypes')->find($ingredientId);
+        $location = Location::find($locationId);
+
+        if (! $ingredient || ! $location) {
+            return null;
+        }
+
+        $shelfLife = $ingredient->category
+            ->locationTypes()
+            ->where('location_type_id', $location->location_type_id)
+            ->first()
+            ?->pivot->shelf_life_hours;
+
+        if (! $shelfLife) {
+            return null;
+        }
+
+        return Perishable::create([
+            'ingredient_id' => $ingredientId,
+            'location_id' => $locationId,
+            'company_id' => $companyId,
+            'quantity' => $quantity,
+        ]);
+    }
+
+    public function remove(int $ingredientId, int $locationId, int $companyId, float $quantity): void
+    {
+        $perishables = Perishable::with(['ingredient.category.locationTypes', 'location'])
+            ->where('ingredient_id', $ingredientId)
+            ->where('location_id', $locationId)
+            ->where('company_id', $companyId)
+            ->get()
+            ->filter(fn ($p) => $this->expiration($p)->isFuture())
+            ->sortBy(fn ($p) => $this->expiration($p));
+
+        foreach ($perishables as $perishable) {
+            if ($quantity <= 0) {
+                break;
+            }
+
+            $remove = min($perishable->quantity, $quantity);
+            $perishable->quantity -= $remove;
+            $quantity -= $remove;
+
+            if ($perishable->quantity <= 0) {
+                $perishable->delete();
+            } else {
+                $perishable->save();
+            }
+        }
+    }
+
+    public function expiration(Perishable $perishable): Carbon
+    {
+        $locationTypeId = $perishable->location->location_type_id;
+        $shelfLife = $perishable->ingredient->category
+            ->locationTypes()
+            ->where('location_type_id', $locationTypeId)
+            ->first()
+            ?->pivot->shelf_life_hours;
+
+        if (! $shelfLife) {
+            return Carbon::create(9999, 12, 31, 23, 59, 59);
+        }
+
+        return $perishable->created_at->copy()->addHours($shelfLife);
+    }
+}
+

--- a/database/factories/PerishableFactory.php
+++ b/database/factories/PerishableFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Perishable;
+use App\Models\Ingredient;
+use App\Models\Location;
+use App\Models\Company;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Perishable>
+ */
+class PerishableFactory extends Factory
+{
+    protected $model = Perishable::class;
+
+    /**
+     * Define the model's default state.
+     */
+    public function definition(): array
+    {
+        return [
+            'quantity' => $this->faker->randomFloat(2, 0.1, 20),
+            'company_id' => Company::factory(),
+        ];
+    }
+
+    public function configure(): static
+    {
+        return $this->afterMaking(function (Perishable $perishable) {
+            $companyId = $perishable->company_id ?? Company::factory()->create()->id;
+            $perishable->company_id = $companyId;
+
+            if (! $perishable->ingredient_id) {
+                $perishable->ingredient_id = Ingredient::factory()->create([
+                    'company_id' => $companyId,
+                ])->id;
+            }
+
+            if (! $perishable->location_id) {
+                $perishable->location_id = Location::factory()->create([
+                    'company_id' => $companyId,
+                ])->id;
+            }
+        });
+    }
+}
+

--- a/database/migrations/2025_08_30_000014_create_perishables_table.php
+++ b/database/migrations/2025_08_30_000014_create_perishables_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('perishables', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('ingredient_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('location_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('company_id')->constrained()->cascadeOnDelete();
+            $table->decimal('quantity', 8, 2);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('perishables');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,6 +17,7 @@ class DatabaseSeeder extends Seeder
             CategorySeeder::class,
             LocationSeeder::class,
             IngredientSeeder::class,
+            PerishableSeeder::class,
             PreparationSeeder::class,
             StockMovementSeeder::class,
             LossSeeder::class,

--- a/database/seeders/IngredientSeeder.php
+++ b/database/seeders/IngredientSeeder.php
@@ -91,10 +91,14 @@ class IngredientSeeder extends Seeder
         foreach ($ingredients as $ingredient) {
             $randomLocations = $company->locations->random(rand(1, $company->locations->count()));
             foreach ($randomLocations as $location) {
+                $quantity = rand(1, 5) === 1 ? 0 : rand(0, 15) + (rand(50, 99) / 100);
+
                 $ingredient->locations()->attach($location->id, [
                     // 1/5 out of stock, sinon entre 0.50 et 15.99
-                    'quantity' => rand(1, 5) === 1 ? 0 : rand(0, 15) + (rand(50, 99) / 100),
+                    'quantity' => $quantity,
                 ]);
+
+                // Perishable batches are seeded separately
             }
         }
     }
@@ -109,9 +113,12 @@ class IngredientSeeder extends Seeder
                 foreach ($ingredients as $ingredient) {
                     $randomLocations = $company->locations->random(rand(1, $company->locations->count()));
                     foreach ($randomLocations as $location) {
+                        $quantity = rand(1, 5) === 1 ? 0 : rand(0, 15) + (rand(50, 99) / 100);
                         $ingredient->locations()->attach($location->id, [
-                            'quantity' => rand(1, 5) === 1 ? 0 : rand(0, 15) + (rand(50, 99) / 100),
+                            'quantity' => $quantity,
                         ]);
+
+                        // Perishable batches are seeded separately
                     }
                 }
             });

--- a/database/seeders/PerishableSeeder.php
+++ b/database/seeders/PerishableSeeder.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Ingredient;
+use App\Models\Loss;
+use App\Services\PerishableService;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class PerishableSeeder extends Seeder
+{
+    public function run(PerishableService $service): void
+    {
+        $rows = DB::table('ingredient_location')->where('quantity', '>', 0)->get();
+
+        $statuses = ['ACTIVE', 'SOON', 'EXPIRED'];
+        $index = 0;
+
+        foreach ($rows as $row) {
+            $ingredient = Ingredient::find($row->ingredient_id);
+            if (! $ingredient) {
+                continue;
+            }
+            $companyId = $ingredient->company_id;
+
+            $perishable = $service->add($row->ingredient_id, $row->location_id, $companyId, $row->quantity);
+            if (! $perishable) {
+                continue; // not perishable
+            }
+
+            $shelfLife = $service->expiration($perishable)->diffInHours($perishable->created_at);
+            $status = $statuses[$index % count($statuses)];
+            $index++;
+
+            if ($status === 'SOON') {
+                $perishable->created_at = now()->subHours(max($shelfLife - 24, 1));
+                $perishable->save();
+            } elseif ($status === 'EXPIRED') {
+                $perishable->created_at = now()->subHours($shelfLife + 1);
+                $perishable->save();
+
+                Loss::create([
+                    'lossable_id' => $perishable->ingredient_id,
+                    'lossable_type' => Ingredient::class,
+                    'location_id' => $perishable->location_id,
+                    'company_id' => $perishable->company_id,
+                    'user_id' => null,
+                    'quantity' => $perishable->quantity,
+                    'reason' => 'expired',
+                ]);
+
+                $perishable->delete();
+            }
+        }
+    }
+}

--- a/graphql/models/perishable.graphql
+++ b/graphql/models/perishable.graphql
@@ -1,0 +1,22 @@
+enum PerishableFilter {
+    ACTIVE
+    SOON
+    EXPIRED
+}
+
+type Perishable {
+    id: ID!
+    ingredient: Ingredient! @belongsTo
+    location: Location! @belongsTo
+    quantity: Float!
+    expiration_at: DateTime!
+    created_at: DateTime!
+    updated_at: DateTime!
+}
+
+extend type Query @guard {
+    perishables(filter: PerishableFilter = ACTIVE): [Perishable!]!
+        @field(resolver: "App\\GraphQL\\Queries\\PerishableQuery@resolve")
+    nonPerishableIngredients: [Ingredient!]!
+        @field(resolver: "App\\GraphQL\\Queries\\NonPerishableIngredientsQuery@resolve")
+}

--- a/tests/Feature/PerishableQueryTest.php
+++ b/tests/Feature/PerishableQueryTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Category;
+use App\Models\Company;
+use App\Models\Ingredient;
+use App\Models\Location;
+use App\Models\LocationType;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Tests\TestCase;
+
+class PerishableQueryTest extends TestCase
+{
+    use RefreshDatabase;
+    use MakesGraphQLRequests;
+
+    /** Scenario: GraphQL perishables query lists active perishable stock. */
+    public function test_it_lists_active_perishables(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+        $locationType = LocationType::factory()->create();
+        $location = Location::factory()->create([
+            'company_id' => $company->id,
+            'location_type_id' => $locationType->id,
+        ]);
+        $category = Category::factory()->create(['company_id' => $company->id]);
+        $category->locationTypes()->attach($locationType->id, ['shelf_life_hours' => 24]);
+        $ingredient = Ingredient::factory()->create([
+            'company_id' => $company->id,
+            'category_id' => $category->id,
+        ]);
+        $ingredient->locations()->updateExistingPivot($location->id, ['quantity' => 0]);
+
+        $this->actingAs($user)->postJson("/api/ingredients/{$ingredient->id}/adjust-quantity", [
+            'location_id' => $location->id,
+            'quantity' => 7.5,
+        ])->assertStatus(200);
+
+        $response = $this->actingAs($user)->graphQL(/** @lang GraphQL */ '
+            query {
+                perishables(filter: ACTIVE) {
+                    ingredient { id }
+                    quantity
+                    expiration_at
+                }
+            }
+        ');
+
+        $response->assertJson([
+            'data' => [
+                'perishables' => [
+                    [
+                        'ingredient' => ['id' => (string) $ingredient->id],
+                        'quantity' => 7.5,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertNotNull(data_get($response->json(), 'data.perishables.0.expiration_at'));
+    }
+}
+

--- a/tests/Feature/PreparationControllerTest.php
+++ b/tests/Feature/PreparationControllerTest.php
@@ -9,6 +9,7 @@ use App\Models\Location;
 use App\Models\LocationType;
 use App\Models\Preparation;
 use App\Models\PreparationEntity;
+use App\Models\Perishable;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
@@ -803,6 +804,59 @@ class PreparationControllerTest extends TestCase
 
         // Quantité destination
         $this->assertDatabaseHas('location_preparation', ['preparation_id' => $preparation->id, 'location_id' => $location2->id, 'quantity' => 2.5]);
+    }
+
+    /** Scénario : la préparation retire les quantités correspondantes dans les périssables. */
+    public function test_prepare_removes_perime_quantities(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+
+        $ingredient = Ingredient::factory()->create(['company_id' => $company->id]);
+        $source = Location::factory()->create(['company_id' => $company->id]);
+        $destination = Location::factory()->create(['company_id' => $company->id]);
+
+        $ingredient->locations()->updateExistingPivot($source->id, ['quantity' => 5]);
+
+        Perishable::create([
+            'ingredient_id' => $ingredient->id,
+            'location_id' => $source->id,
+            'company_id' => $company->id,
+            'quantity' => 5,
+        ]);
+
+        $preparation = Preparation::factory()->create(['company_id' => $company->id]);
+        PreparationEntity::create([
+            'preparation_id' => $preparation->id,
+            'entity_id' => $ingredient->id,
+            'entity_type' => Ingredient::class,
+        ]);
+
+        $payload = [
+            'quantity' => 1,
+            'location_id' => $destination->id,
+            'components' => [
+                [
+                    'entity_id' => $ingredient->id,
+                    'entity_type' => 'ingredient',
+                    'quantity' => 2,
+                    'sources' => [
+                        ['location_id' => $source->id, 'quantity' => 2],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->actingAs($user)
+            ->postJson("/api/preparations/{$preparation->id}/prepare", $payload)
+            ->assertStatus(200);
+
+        $this->assertDatabaseHas('perishables', [
+            'ingredient_id' => $ingredient->id,
+            'location_id' => $source->id,
+            'company_id' => $company->id,
+            'quantity' => 3,
+        ]);
     }
 
     /** Scénario : préparation avec plusieurs emplacements sources. */

--- a/tests/Feature/QuantityAdjustmentTest.php
+++ b/tests/Feature/QuantityAdjustmentTest.php
@@ -2,9 +2,11 @@
 
 namespace Tests\Feature;
 
+use App\Models\Category;
 use App\Models\Company;
 use App\Models\Ingredient;
 use App\Models\Location;
+use App\Models\LocationType;
 use App\Models\Preparation;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -14,12 +16,22 @@ class QuantityAdjustmentTest extends TestCase
 {
     use RefreshDatabase;
 
+    /** Scénario : ajustement de la quantité d'un ingrédient avec suivi des périssables. */
     public function test_it_adjusts_ingredient_quantity(): void
     {
         $company = Company::factory()->create();
         $user = User::factory()->create(['company_id' => $company->id]);
-        $location = Location::factory()->create(['company_id' => $company->id]);
-        $ingredient = Ingredient::factory()->create(['company_id' => $company->id]);
+        $locationType = LocationType::factory()->create();
+        $location = Location::factory()->create([
+            'company_id' => $company->id,
+            'location_type_id' => $locationType->id,
+        ]);
+        $category = Category::factory()->create(['company_id' => $company->id]);
+        $category->locationTypes()->attach($locationType->id, ['shelf_life_hours' => 24]);
+        $ingredient = Ingredient::factory()->create([
+            'company_id' => $company->id,
+            'category_id' => $category->id,
+        ]);
         $ingredient->locations()->updateExistingPivot($location->id, ['quantity' => 5]);
 
         $this->actingAs($user)
@@ -34,8 +46,57 @@ class QuantityAdjustmentTest extends TestCase
             'location_id' => $location->id,
             'quantity' => 12.5,
         ]);
+
+        $this->assertDatabaseHas('perishables', [
+            'ingredient_id' => $ingredient->id,
+            'location_id' => $location->id,
+            'company_id' => $company->id,
+            'quantity' => 7.5,
+        ]);
+
+        $this->actingAs($user)
+            ->postJson("/api/ingredients/{$ingredient->id}/adjust-quantity", [
+                'location_id' => $location->id,
+                'quantity' => -2,
+            ])
+            ->assertStatus(200);
+
+        $this->assertDatabaseHas('perishables', [
+            'ingredient_id' => $ingredient->id,
+            'location_id' => $location->id,
+            'company_id' => $company->id,
+            'quantity' => 5.5,
+        ]);
     }
 
+    /** Scénario : aucun enregistrement périssable si la durée de vie est absente. */
+    public function test_it_skips_perishable_when_no_shelf_life(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+        $locationType = LocationType::factory()->create();
+        $location = Location::factory()->create([
+            'company_id' => $company->id,
+            'location_type_id' => $locationType->id,
+        ]);
+        $category = Category::factory()->create(['company_id' => $company->id]);
+        $ingredient = Ingredient::factory()->create([
+            'company_id' => $company->id,
+            'category_id' => $category->id,
+        ]);
+        $ingredient->locations()->updateExistingPivot($location->id, ['quantity' => 5]);
+
+        $this->actingAs($user)
+            ->postJson("/api/ingredients/{$ingredient->id}/adjust-quantity", [
+                'location_id' => $location->id,
+                'quantity' => 2,
+            ])
+            ->assertStatus(200);
+
+        $this->assertDatabaseCount('perishables', 0);
+    }
+
+    /** Scénario : rejet lorsqu'un ajustement rend la quantité négative. */
     public function test_it_prevents_negative_ingredient_quantity(): void
     {
         $company = Company::factory()->create();
@@ -58,6 +119,7 @@ class QuantityAdjustmentTest extends TestCase
         ]);
     }
 
+    /** Scénario : ajustement de la quantité d'une préparation. */
     public function test_it_adjusts_preparation_quantity(): void
     {
         $company = Company::factory()->create();
@@ -80,6 +142,7 @@ class QuantityAdjustmentTest extends TestCase
         ]);
     }
 
+    /** Scénario : refus d'une quantité négative pour une préparation. */
     public function test_it_prevents_negative_preparation_quantity(): void
     {
         $company = Company::factory()->create();

--- a/tests/Unit/PerishableTest.php
+++ b/tests/Unit/PerishableTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Category;
+use App\Models\Company;
+use App\Models\Ingredient;
+use App\Models\Location;
+use App\Models\LocationType;
+use App\Models\Perishable;
+use App\Models\Loss;
+use App\Models\User;
+use App\Services\PerishableService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PerishableTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** Scénario : retrait en priorité des lots avec expiration la plus proche en ignorant les périmés. */
+    public function test_remove_quantity_skips_expired_and_prioritizes_earliest_expiration(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+        $this->actingAs($user);
+
+        $category = Category::factory()->create(['company_id' => $company->id]);
+        $ingredient = Ingredient::factory()->create([
+            'company_id' => $company->id,
+            'category_id' => $category->id,
+        ]);
+        $locationType = LocationType::factory()->create();
+        $location = Location::factory()->create([
+            'company_id' => $company->id,
+            'location_type_id' => $locationType->id,
+        ]);
+
+        $category->locationTypes()->attach($locationType->id, ['shelf_life_hours' => 24]);
+
+        $p1 = Perishable::create([
+            'ingredient_id' => $ingredient->id,
+            'location_id' => $location->id,
+            'company_id' => $company->id,
+            'quantity' => 2,
+        ]);
+        $p1->forceFill(['created_at' => now()->subDays(3), 'updated_at' => now()->subDays(3)])->save();
+
+        $p2 = Perishable::create([
+            'ingredient_id' => $ingredient->id,
+            'location_id' => $location->id,
+            'company_id' => $company->id,
+            'quantity' => 2,
+        ]);
+        $p2->forceFill(['created_at' => now()->subHours(10), 'updated_at' => now()->subHours(10)])->save();
+
+        Perishable::create([
+            'ingredient_id' => $ingredient->id,
+            'location_id' => $location->id,
+            'company_id' => $company->id,
+            'quantity' => 2,
+        ]);
+
+        $service = new PerishableService();
+        $service->remove($ingredient->id, $location->id, $company->id, 3);
+
+        $this->assertSame(2, Perishable::count());
+        $this->assertDatabaseHas('perishables', [
+            'ingredient_id' => $ingredient->id,
+            'location_id' => $location->id,
+            'company_id' => $company->id,
+            'quantity' => 2,
+        ]);
+        $this->assertDatabaseHas('perishables', [
+            'ingredient_id' => $ingredient->id,
+            'location_id' => $location->id,
+            'company_id' => $company->id,
+            'quantity' => 1,
+        ]);
+    }
+
+    /** Scénario : la commande d'expiration crée une perte et soft-delete les lots périmés. */
+    public function test_expire_command_creates_loss_and_soft_deletes(): void
+    {
+        $company = Company::factory()->create();
+        $category = Category::factory()->create(['company_id' => $company->id]);
+        $ingredient = Ingredient::factory()->create([
+            'company_id' => $company->id,
+            'category_id' => $category->id,
+        ]);
+        $locationType = LocationType::factory()->create();
+        $location = Location::factory()->create([
+            'company_id' => $company->id,
+            'location_type_id' => $locationType->id,
+        ]);
+
+        $category->locationTypes()->attach($locationType->id, ['shelf_life_hours' => 1]);
+
+        $perishable = Perishable::create([
+            'ingredient_id' => $ingredient->id,
+            'location_id' => $location->id,
+            'company_id' => $company->id,
+            'quantity' => 4,
+        ]);
+        $perishable->forceFill(['created_at' => now()->subHours(2), 'updated_at' => now()->subHours(2)])->save();
+
+        $this->artisan('perishables:expire')->assertExitCode(0);
+
+        $this->assertSoftDeleted('perishables', ['id' => $perishable->id]);
+        $this->assertDatabaseHas('losses', [
+            'lossable_id' => $ingredient->id,
+            'lossable_type' => Ingredient::class,
+            'location_id' => $location->id,
+            'company_id' => $company->id,
+            'quantity' => 4,
+            'reason' => 'expired',
+        ]);
+    }
+}
+


### PR DESCRIPTION
## Summary
- remove perishable logging from ingredient seeder
- add perishable seeder generating active, soon, and expired batches
- register new perishable seeder in main database seeder

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68b2220c90d8832dbd91b9152d72b161