### PR TITLE
Enforce unique ingredient/preparation per location

### DIFF
--- a/database/migrations/2025_07_07_213732_create_ingredients_locations_tables.php
+++ b/database/migrations/2025_07_07_213732_create_ingredients_locations_tables.php
@@ -54,6 +54,8 @@ return new class extends Migration
             $table->foreignId('location_id')->constrained()->onDelete('cascade')->nullable(false);
             $table->decimal('quantity', 8, 2)->default(0)->nullable(false);
             $table->timestamps();
+
+            $table->unique(['ingredient_id', 'location_id']);
         });
     }
 

--- a/database/migrations/2025_07_30_175316_add_location_and_quantity_to_preparation.php
+++ b/database/migrations/2025_07_30_175316_add_location_and_quantity_to_preparation.php
@@ -14,6 +14,8 @@ return new class extends Migration
             $table->foreignId('location_id')->constrained()->onDelete('cascade')->nullable(false);
             $table->decimal('quantity', 8, 2)->default(0)->nullable(false);
             $table->timestamps();
+
+            $table->unique(['preparation_id', 'location_id']);
         });
     }
 

--- a/database/seeders/IngredientSeeder.php
+++ b/database/seeders/IngredientSeeder.php
@@ -90,12 +90,16 @@ class IngredientSeeder extends Seeder
 
         foreach ($ingredients as $ingredient) {
             $randomLocations = $company->locations->random(rand(1, $company->locations->count()));
+            $locationData = [];
+
             foreach ($randomLocations as $location) {
-                $ingredient->locations()->attach($location->id, [
+                $locationData[$location->id] = [
                     // 1/5 out of stock, sinon entre 0.50 et 15.99
                     'quantity' => rand(1, 5) === 1 ? 0 : rand(0, 15) + (rand(50, 99) / 100),
-                ]);
+                ];
             }
+
+            $ingredient->locations()->syncWithoutDetaching($locationData);
         }
     }
 
@@ -108,11 +112,15 @@ class IngredientSeeder extends Seeder
 
                 foreach ($ingredients as $ingredient) {
                     $randomLocations = $company->locations->random(rand(1, $company->locations->count()));
+                    $locationData = [];
+
                     foreach ($randomLocations as $location) {
-                        $ingredient->locations()->attach($location->id, [
+                        $locationData[$location->id] = [
                             'quantity' => rand(1, 5) === 1 ? 0 : rand(0, 15) + (rand(50, 99) / 100),
-                        ]);
+                        ];
                     }
+
+                    $ingredient->locations()->syncWithoutDetaching($locationData);
                 }
             });
     }

--- a/database/seeders/PreparationSeeder.php
+++ b/database/seeders/PreparationSeeder.php
@@ -79,7 +79,7 @@ class PreparationSeeder extends Seeder
                 }
 
                 // Attache les emplacements avec leurs quantités
-                $preparation->locations()->attach($locationData);
+                $preparation->locations()->syncWithoutDetaching($locationData);
             }
 
             // Attache une catégorie aléatoire à la préparation
@@ -124,7 +124,7 @@ class PreparationSeeder extends Seeder
                     }
 
                     // Attache les emplacements avec leurs quantités
-                    $preparation->locations()->attach($locationData);
+                    $preparation->locations()->syncWithoutDetaching($locationData);
                 }
 
                 // Attache une catégorie aléatoire à la préparation

--- a/tests/Feature/LocationControllerTest.php
+++ b/tests/Feature/LocationControllerTest.php
@@ -234,7 +234,9 @@ class LocationControllerTest extends TestCase
             'unit' => 'kg',
         ]);
 
-        $location->ingredients()->attach($ingredient->id);
+        $location->ingredients()->syncWithoutDetaching([
+            $ingredient->id => ['quantity' => 1],
+        ]);
 
         $response = $this->deleteJson("/api/location/{$location->id}");
 


### PR DESCRIPTION
## Summary
- enforce unique ingredient/location and preparation/location pivot pairs
- seed ingredient and preparation locations without duplicates
- adapt location removal test for uniqueness

## Testing
- `./vendor/bin/pint`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68b2ff960768832d93e2276a08df1350