### PR TITLE
Reduce zero-quantity rate in seeders

### DIFF
--- a/database/seeders/IngredientSeeder.php
+++ b/database/seeders/IngredientSeeder.php
@@ -94,8 +94,8 @@ class IngredientSeeder extends Seeder
 
             foreach ($randomLocations as $location) {
                 $locationData[$location->id] = [
-                    // 1/5 out of stock, sinon entre 0.50 et 15.99
-                    'quantity' => rand(1, 5) === 1 ? 0 : rand(0, 15) + (rand(50, 99) / 100),
+                    // 1/10 out of stock, sinon entre 0.50 et 15.99
+                    'quantity' => rand(1, 10) === 1 ? 0 : rand(0, 15) + (rand(50, 99) / 100),
                 ];
             }
 
@@ -116,7 +116,8 @@ class IngredientSeeder extends Seeder
 
                     foreach ($randomLocations as $location) {
                         $locationData[$location->id] = [
-                            'quantity' => rand(1, 5) === 1 ? 0 : rand(0, 15) + (rand(50, 99) / 100),
+                            // 1/10 out of stock, sinon entre 0.50 et 15.99
+                            'quantity' => rand(1, 10) === 1 ? 0 : rand(0, 15) + (rand(50, 99) / 100),
                         ];
                     }
 

--- a/database/seeders/PreparationSeeder.php
+++ b/database/seeders/PreparationSeeder.php
@@ -83,7 +83,7 @@ class PreparationSeeder extends Seeder
 
                 foreach ($usedLocations as $location) {
                     $locationData[$location->id] = [
-                        'quantity' => rand(1, 5) === 1 ? 0 : rand(1, 20) + (rand(0, 100) / 100), // 1/5 chance d'être out of stock, sinon entre 1.00 et 20.99
+                        'quantity' => rand(1, 10) === 1 ? 0 : rand(1, 20) + (rand(0, 100) / 100), // 1/10 chance d'être out of stock, sinon entre 1.00 et 20.99
                     ];
                 }
 


### PR DESCRIPTION
## Summary
- Lower chance of zero stock when seeding ingredients and preparations

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b30427bef8832d91aac2e8b2404a3f