### PR TITLE
 feat: split quantity adjustment into add and remove

### DIFF
--- a/app/Services/StockService.php
+++ b/app/Services/StockService.php
@@ -44,4 +44,3 @@ class StockService
         return $newQuantity;
     }
 }
-

--- a/app/Services/StockService.php
+++ b/app/Services/StockService.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Ingredient;
+use App\Models\Location;
+use App\Models\Preparation;
+
+class StockService
+{
+    public function add(Ingredient|Preparation $model, int $locationId, int $companyId, float $quantity): float
+    {
+        $location = Location::where('id', $locationId)
+            ->where('company_id', $companyId)
+            ->firstOrFail();
+
+        $current = (float) ($model->locations()->find($location->id)?->pivot->quantity ?? 0);
+        $newQuantity = $current + $quantity;
+
+        $model->locations()->syncWithoutDetaching([
+            $location->id => ['quantity' => $newQuantity],
+        ]);
+
+        return $newQuantity;
+    }
+
+    public function remove(Ingredient|Preparation $model, int $locationId, int $companyId, float $quantity): float
+    {
+        $location = Location::where('id', $locationId)
+            ->where('company_id', $companyId)
+            ->firstOrFail();
+
+        $current = (float) ($model->locations()->find($location->id)?->pivot->quantity ?? 0);
+        $newQuantity = $current - $quantity;
+
+        if ($newQuantity < 0) {
+            throw new \InvalidArgumentException('Quantity cannot be negative');
+        }
+
+        $model->locations()->syncWithoutDetaching([
+            $location->id => ['quantity' => $newQuantity],
+        ]);
+
+        return $newQuantity;
+    }
+}
+

--- a/routes/authed_route.php
+++ b/routes/authed_route.php
@@ -30,7 +30,8 @@ Route::prefix('preparations')->name('preparations.')->group(function () {
     Route::put('/{id}', [PreparationController::class, 'update'])->name('update');
     Route::delete('/{id}', [PreparationController::class, 'destroy'])->name('destroy');
     Route::post('/{id}/prepare', [PreparationController::class, 'prepare'])->name('prepare');
-    Route::post('/{id}/adjust-quantity', [PreparationController::class, 'adjustQuantity'])->name('adjust-quantity');
+    Route::post('/{id}/add-quantity', [PreparationController::class, 'addQuantity'])->name('add-quantity');
+    Route::post('/{id}/remove-quantity', [PreparationController::class, 'removeQuantity'])->name('remove-quantity');
 });
 
 // Groupe de routes pour les ingrédients
@@ -38,7 +39,8 @@ Route::prefix('ingredients')->name('ingredients.')->group(function () {
     Route::post('/', [IngredientController::class, 'store'])->name('store');
     Route::put('/{ingredient}', [IngredientController::class, 'update'])->name('update');
     Route::delete('/{ingredient}', [IngredientController::class, 'destroy'])->name('destroy');
-    Route::post('/{ingredient}/adjust-quantity', [IngredientController::class, 'adjustQuantity'])->name('adjust-quantity');
+    Route::post('/{ingredient}/add-quantity', [IngredientController::class, 'addQuantity'])->name('add-quantity');
+    Route::post('/{ingredient}/remove-quantity', [IngredientController::class, 'removeQuantity'])->name('remove-quantity');
 });
 
 // Groupe de routes pour les types de localisation

--- a/tests/Feature/PerishableQueryTest.php
+++ b/tests/Feature/PerishableQueryTest.php
@@ -43,12 +43,12 @@ class PerishableQueryTest extends TestCase
         $freshIngredient->locations()->updateExistingPivot($location->id, ['quantity' => 0]);
         $soonIngredient->locations()->updateExistingPivot($location->id, ['quantity' => 0]);
 
-        $this->actingAs($user)->postJson("/api/ingredients/{$freshIngredient->id}/adjust-quantity", [
+        $this->actingAs($user)->postJson("/api/ingredients/{$freshIngredient->id}/add-quantity", [
             'location_id' => $location->id,
             'quantity' => 7.5,
         ])->assertStatus(200);
 
-        $this->actingAs($user)->postJson("/api/ingredients/{$soonIngredient->id}/adjust-quantity", [
+        $this->actingAs($user)->postJson("/api/ingredients/{$soonIngredient->id}/add-quantity", [
             'location_id' => $location->id,
             'quantity' => 2,
         ])->assertStatus(200);
@@ -96,7 +96,7 @@ class PerishableQueryTest extends TestCase
         ]);
         $ingredient->locations()->updateExistingPivot($location->id, ['quantity' => 0]);
 
-        $this->actingAs($user)->postJson("/api/ingredients/{$ingredient->id}/adjust-quantity", [
+        $this->actingAs($user)->postJson("/api/ingredients/{$ingredient->id}/add-quantity", [
             'location_id' => $location->id,
             'quantity' => 1,
         ])->assertStatus(200);
@@ -142,7 +142,7 @@ class PerishableQueryTest extends TestCase
         ]);
         $ingredient->locations()->updateExistingPivot($location->id, ['quantity' => 0]);
 
-        $this->actingAs($user)->postJson("/api/ingredients/{$ingredient->id}/adjust-quantity", [
+        $this->actingAs($user)->postJson("/api/ingredients/{$ingredient->id}/add-quantity", [
             'location_id' => $location->id,
             'quantity' => 2,
         ])->assertStatus(200);

--- a/tests/Feature/QuantityAdjustmentTest.php
+++ b/tests/Feature/QuantityAdjustmentTest.php
@@ -35,7 +35,7 @@ class QuantityAdjustmentTest extends TestCase
         $ingredient->locations()->updateExistingPivot($location->id, ['quantity' => 5]);
 
         $this->actingAs($user)
-            ->postJson("/api/ingredients/{$ingredient->id}/adjust-quantity", [
+            ->postJson("/api/ingredients/{$ingredient->id}/add-quantity", [
                 'location_id' => $location->id,
                 'quantity' => 7.5,
             ])
@@ -55,9 +55,9 @@ class QuantityAdjustmentTest extends TestCase
         ]);
 
         $this->actingAs($user)
-            ->postJson("/api/ingredients/{$ingredient->id}/adjust-quantity", [
+            ->postJson("/api/ingredients/{$ingredient->id}/remove-quantity", [
                 'location_id' => $location->id,
-                'quantity' => -2,
+                'quantity' => 2,
             ])
             ->assertStatus(200);
 
@@ -87,7 +87,7 @@ class QuantityAdjustmentTest extends TestCase
         $ingredient->locations()->updateExistingPivot($location->id, ['quantity' => 5]);
 
         $this->actingAs($user)
-            ->postJson("/api/ingredients/{$ingredient->id}/adjust-quantity", [
+            ->postJson("/api/ingredients/{$ingredient->id}/add-quantity", [
                 'location_id' => $location->id,
                 'quantity' => 2,
             ])
@@ -106,9 +106,9 @@ class QuantityAdjustmentTest extends TestCase
         $ingredient->locations()->updateExistingPivot($location->id, ['quantity' => 5]);
 
         $this->actingAs($user)
-            ->postJson("/api/ingredients/{$ingredient->id}/adjust-quantity", [
+            ->postJson("/api/ingredients/{$ingredient->id}/remove-quantity", [
                 'location_id' => $location->id,
-                'quantity' => -10,
+                'quantity' => 10,
             ])
             ->assertStatus(422);
 
@@ -129,7 +129,7 @@ class QuantityAdjustmentTest extends TestCase
         $preparation->locations()->updateExistingPivot($location->id, ['quantity' => 2]);
 
         $this->actingAs($user)
-            ->postJson("/api/preparations/{$preparation->id}/adjust-quantity", [
+            ->postJson("/api/preparations/{$preparation->id}/add-quantity", [
                 'location_id' => $location->id,
                 'quantity' => 5,
             ])
@@ -152,9 +152,9 @@ class QuantityAdjustmentTest extends TestCase
         $preparation->locations()->updateExistingPivot($location->id, ['quantity' => 3]);
 
         $this->actingAs($user)
-            ->postJson("/api/preparations/{$preparation->id}/adjust-quantity", [
+            ->postJson("/api/preparations/{$preparation->id}/remove-quantity", [
                 'location_id' => $location->id,
-                'quantity' => -5,
+                'quantity' => 5,
             ])
             ->assertStatus(422);
 


### PR DESCRIPTION
## Summary
- restrict StockService to Ingredient or Preparation models
- ensure add/remove stock methods call locations relation safely

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b3243ef238832da788467b3903c782