### PR TITLE
feat: order ingredient stock movements

### DIFF
--- a/app/GraphQL/Resolvers/IngredientResolver.php
+++ b/app/GraphQL/Resolvers/IngredientResolver.php
@@ -32,4 +32,25 @@ class IngredientResolver
 
         return $quantities;
     }
+
+    /**
+     * Retrieve stock movements for an ingredient with optional ordering.
+     *
+     * @param  array<string, mixed>  $args
+     */
+    public function stockMovements(Ingredient $ingredient, array $args)
+    {
+        $query = $ingredient->stockMovements();
+
+        $orders = $args['orderBy'] ?? [[
+            'column' => 'created_at',
+            'order' => 'DESC',
+        ]];
+
+        foreach ($orders as $order) {
+            $query->orderBy($order['column'], $order['order']);
+        }
+
+        return $query->get();
+    }
 }

--- a/graphql/models/ingredient.graphql
+++ b/graphql/models/ingredient.graphql
@@ -25,7 +25,10 @@ type Ingredient {
         @field(resolver: "App\\GraphQL\\Resolvers\\IngredientResolver@imageUrl")
 
     "Historique des mouvements de stock pour cet ingrédient"
-    stockMovements: [StockMovement!]! @morphMany
+    stockMovements(
+        orderBy: [StockMovementOrderByClause!]
+    ): [StockMovement!]!
+        @field(resolver: "App\\GraphQL\\Resolvers\\IngredientResolver@stockMovements")
 
     withdrawals_today_count: Int!
 

--- a/graphql/models/stockMovement.graphql
+++ b/graphql/models/stockMovement.graphql
@@ -66,7 +66,7 @@ extend type Query @guard {
 "Options de tri pour les mouvements de stock."
 input StockMovementOrderByClause {
     "Champ sur lequel effectuer le tri."
-    field: StockMovementOrderByField!
+    column: StockMovementOrderByField!
 
     "Direction du tri."
     order: SortOrder!

--- a/tests/Feature/IngredientStockMovementsOrderTest.php
+++ b/tests/Feature/IngredientStockMovementsOrderTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Company;
+use App\Models\Ingredient;
+use App\Models\Location;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Tests\TestCase;
+
+class IngredientStockMovementsOrderTest extends TestCase
+{
+    use MakesGraphQLRequests;
+    use RefreshDatabase;
+
+    public function test_it_orders_stock_movements_by_created_at_desc(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+        $location = Location::factory()->create(['company_id' => $company->id]);
+        $ingredient = Ingredient::factory()->create(['company_id' => $company->id]);
+
+        $this->actingAs($user);
+
+        $first = $ingredient->recordStockMovement($location, 0, 5);
+        $first->created_at = Carbon::now()->subDay();
+        $first->save();
+
+        $second = $ingredient->recordStockMovement($location, 5, 3);
+        $second->created_at = Carbon::now();
+        $second->save();
+
+        $response = $this->graphQL(/** @lang GraphQL */ '
+            query ($id: ID!) {
+                ingredient(id: $id) {
+                    stockMovements(orderBy: [{column: CREATED_AT, order: DESC}]) {
+                        id
+                    }
+                }
+            }
+        ', ['id' => $ingredient->id]);
+
+        $response->assertJson([
+            'data' => [
+                'ingredient' => [
+                    'stockMovements' => [
+                        ['id' => (string) $second->id],
+                        ['id' => (string) $first->id],
+                    ],
+                ],
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- enable stock movement ordering when querying a single ingredient
- restrict ordering to predefined fields via `StockMovementOrderByClause`
- test ingredient stock movement ordering by created_at desc

## Testing
- ⚠️ `make pint` (docker-compose: No such file or directory)
- ⚠️ `make larastan` (docker-compose: No such file or directory)
- ✅ `./vendor/bin/pint`
- ✅ `./vendor/bin/phpstan analyse --memory-limit=2G`
- ✅ `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b719aefc7c832dbf04e8dfd99cc041