### PR TITLE
Remove automatic zero stock initialization

### DIFF
--- a/app/Models/Ingredient.php
+++ b/app/Models/Ingredient.php
@@ -24,21 +24,6 @@ class Ingredient extends Model
         'unit' => MeasurementUnit::class,
     ];
 
-    protected static function booted()
-    {
-        static::created(function (Ingredient $ingredient) {
-            $locations = Location::where('company_id', $ingredient->company_id)->pluck('id');
-
-            $syncData = $locations
-                ->mapWithKeys(fn ($id) => [$id => ['quantity' => 0]])
-                ->toArray();
-
-            if (! empty($syncData)) {
-                $ingredient->locations()->syncWithoutDetaching($syncData);
-            }
-        });
-    }
-
     public function company(): BelongsTo
     {
         return $this->belongsTo(Company::class);

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -31,29 +31,6 @@ class Location extends Model
         'id',
     ];
 
-    protected static function booted()
-    {
-        static::created(function (Location $location) {
-            $ingredients = Ingredient::where('company_id', $location->company_id)->pluck('id');
-            $ingredientData = $ingredients
-                ->mapWithKeys(fn ($id) => [$id => ['quantity' => 0]])
-                ->toArray();
-
-            if (! empty($ingredientData)) {
-                $location->ingredients()->syncWithoutDetaching($ingredientData);
-            }
-
-            $preparations = Preparation::where('company_id', $location->company_id)->pluck('id');
-            $preparationData = $preparations
-                ->mapWithKeys(fn ($id) => [$id => ['quantity' => 0]])
-                ->toArray();
-
-            if (! empty($preparationData)) {
-                $location->preparations()->syncWithoutDetaching($preparationData);
-            }
-        });
-    }
-
     public function company()
     {
         return $this->belongsTo(Company::class);

--- a/app/Models/Preparation.php
+++ b/app/Models/Preparation.php
@@ -25,21 +25,6 @@ class Preparation extends Model
         'unit' => MeasurementUnit::class,
     ];
 
-    protected static function booted()
-    {
-        static::created(function (Preparation $preparation) {
-            $locations = Location::where('company_id', $preparation->company_id)->pluck('id');
-
-            $syncData = $locations
-                ->mapWithKeys(fn ($id) => [$id => ['quantity' => 0]])
-                ->toArray();
-
-            if (! empty($syncData)) {
-                $preparation->locations()->syncWithoutDetaching($syncData);
-            }
-        });
-    }
-
     /**
      * Get the company that owns the preparation.
      *

--- a/tests/Feature/LossTrackingTest.php
+++ b/tests/Feature/LossTrackingTest.php
@@ -50,7 +50,7 @@ class LossTrackingTest extends TestCase
      */
     public function test_recording_ingredient_loss_updates_stock_and_logs_history(): void
     {
-        $this->ingredient->locations()->updateExistingPivot($this->location->id, ['quantity' => 10]);
+        $this->ingredient->locations()->syncWithoutDetaching([$this->location->id => ['quantity' => 10]]);
         StockMovement::query()->delete();
 
         $response = $this->postJson('/api/losses', [
@@ -91,7 +91,7 @@ class LossTrackingTest extends TestCase
      */
     public function test_recording_preparation_loss_updates_stock_and_logs_history(): void
     {
-        $this->preparation->locations()->updateExistingPivot($this->location->id, ['quantity' => 5]);
+        $this->preparation->locations()->syncWithoutDetaching([$this->location->id => ['quantity' => 5]]);
         StockMovement::query()->delete();
 
         $response = $this->postJson('/api/losses', [
@@ -131,7 +131,7 @@ class LossTrackingTest extends TestCase
      */
     public function test_recording_loss_with_insufficient_stock_returns_error(): void
     {
-        $this->ingredient->locations()->updateExistingPivot($this->location->id, ['quantity' => 2]);
+        $this->ingredient->locations()->syncWithoutDetaching([$this->location->id => ['quantity' => 2]]);
         StockMovement::query()->delete();
 
         $response = $this->postJson('/api/losses', [
@@ -158,7 +158,7 @@ class LossTrackingTest extends TestCase
      */
     public function test_cancelling_loss_restores_stock_and_logs_history(): void
     {
-        $this->ingredient->locations()->updateExistingPivot($this->location->id, ['quantity' => 5]);
+        $this->ingredient->locations()->syncWithoutDetaching([$this->location->id => ['quantity' => 5]]);
         StockMovement::query()->delete();
 
         $storeResponse = $this->postJson('/api/losses', [

--- a/tests/Feature/PerishableQueryTest.php
+++ b/tests/Feature/PerishableQueryTest.php
@@ -40,8 +40,8 @@ class PerishableQueryTest extends TestCase
             'company_id' => $company->id,
             'category_id' => $soonCategory->id,
         ]);
-        $freshIngredient->locations()->updateExistingPivot($location->id, ['quantity' => 0]);
-        $soonIngredient->locations()->updateExistingPivot($location->id, ['quantity' => 0]);
+        $freshIngredient->locations()->syncWithoutDetaching([$location->id => ['quantity' => 0]]);
+        $soonIngredient->locations()->syncWithoutDetaching([$location->id => ['quantity' => 0]]);
 
         $this->actingAs($user)->postJson("/api/ingredients/{$freshIngredient->id}/add-quantity", [
             'location_id' => $location->id,
@@ -94,7 +94,7 @@ class PerishableQueryTest extends TestCase
             'company_id' => $company->id,
             'category_id' => $category->id,
         ]);
-        $ingredient->locations()->updateExistingPivot($location->id, ['quantity' => 0]);
+        $ingredient->locations()->syncWithoutDetaching([$location->id => ['quantity' => 0]]);
 
         $this->actingAs($user)->postJson("/api/ingredients/{$ingredient->id}/add-quantity", [
             'location_id' => $location->id,
@@ -140,7 +140,7 @@ class PerishableQueryTest extends TestCase
             'company_id' => $company->id,
             'category_id' => $category->id,
         ]);
-        $ingredient->locations()->updateExistingPivot($location->id, ['quantity' => 0]);
+        $ingredient->locations()->syncWithoutDetaching([$location->id => ['quantity' => 0]]);
 
         $this->actingAs($user)->postJson("/api/ingredients/{$ingredient->id}/add-quantity", [
             'location_id' => $location->id,

--- a/tests/Feature/PreparationControllerTest.php
+++ b/tests/Feature/PreparationControllerTest.php
@@ -499,7 +499,7 @@ class PreparationControllerTest extends TestCase
         $location = Location::factory()->create(['company_id' => $company->id]);
 
         // Quantité initiale
-        $prep->locations()->updateExistingPivot($location->id, ['quantity' => 5.0]);
+        $prep->locations()->syncWithoutDetaching([$location->id => ['quantity' => 5.0]]);
 
         $payload = [
             'quantities' => [
@@ -692,7 +692,7 @@ class PreparationControllerTest extends TestCase
         ]);
 
         // Ajouter du stock
-        $ing->locations()->updateExistingPivot($source->id, ['quantity' => 10.0]);
+        $ing->locations()->syncWithoutDetaching([$source->id => ['quantity' => 10.0]]);
 
         // Créer une catégorie
         $category = Category::factory()->create([
@@ -766,8 +766,8 @@ class PreparationControllerTest extends TestCase
         $location2 = Location::factory()->create(['company_id' => $company->id, 'name' => 'Cuisine']);
 
         // Stocks
-        $ing1->locations()->updateExistingPivot($location1->id, ['quantity' => 10.0]);
-        $ing2->locations()->updateExistingPivot($location1->id, ['quantity' => 8.0]);
+        $ing1->locations()->syncWithoutDetaching([$location1->id => ['quantity' => 10.0]]);
+        $ing2->locations()->syncWithoutDetaching([$location1->id => ['quantity' => 8.0]]);
 
         // Préparation
         $preparation = Preparation::factory()->create([
@@ -816,7 +816,7 @@ class PreparationControllerTest extends TestCase
         $source = Location::factory()->create(['company_id' => $company->id]);
         $destination = Location::factory()->create(['company_id' => $company->id]);
 
-        $ingredient->locations()->updateExistingPivot($source->id, ['quantity' => 5]);
+        $ingredient->locations()->syncWithoutDetaching([$source->id => ['quantity' => 5]]);
 
         Perishable::create([
             'ingredient_id' => $ingredient->id,
@@ -870,8 +870,8 @@ class PreparationControllerTest extends TestCase
         $location2 = Location::factory()->create(['company_id' => $company->id, 'name' => 'Réserve 2']);
         $destination = Location::factory()->create(['company_id' => $company->id, 'name' => 'Cuisine']);
 
-        $ing->locations()->updateExistingPivot($location1->id, ['quantity' => 5.0]);
-        $ing->locations()->updateExistingPivot($location2->id, ['quantity' => 3.0]);
+        $ing->locations()->syncWithoutDetaching([$location1->id => ['quantity' => 5.0]]);
+        $ing->locations()->syncWithoutDetaching([$location2->id => ['quantity' => 3.0]]);
 
         $preparation = Preparation::factory()->create(['company_id' => $company->id, 'name' => 'Simple preparation', 'unit' => 'kg']);
         PreparationEntity::create(['preparation_id' => $preparation->id, 'entity_id' => $ing->id, 'entity_type' => Ingredient::class]);
@@ -905,7 +905,7 @@ class PreparationControllerTest extends TestCase
         $ing = Ingredient::factory()->create(['company_id' => $company->id, 'name' => 'Farine', 'unit' => 'kg']);
         $location1 = Location::factory()->create(['company_id' => $company->id, 'name' => 'Réserve']);
         $location2 = Location::factory()->create(['company_id' => $company->id, 'name' => 'Cuisine']);
-        $ing->locations()->updateExistingPivot($location1->id, ['quantity' => 2.0]);
+        $ing->locations()->syncWithoutDetaching([$location1->id => ['quantity' => 2.0]]);
 
         $preparation = Preparation::factory()->create(['company_id' => $company->id, 'name' => 'Simple preparation', 'unit' => 'kg']);
         PreparationEntity::create(['preparation_id' => $preparation->id, 'entity_id' => $ing->id, 'entity_type' => Ingredient::class]);
@@ -940,7 +940,7 @@ class PreparationControllerTest extends TestCase
         $freezer = Location::factory()->create(['company_id' => $company->id, 'name' => 'Congélateur principal', 'location_type_id' => $freezerType->id]);
         $kitchen = Location::factory()->create(['company_id' => $company->id, 'name' => 'Cuisine']);
 
-        $ing->locations()->updateExistingPivot($freezer->id, ['quantity' => 5.0]);
+        $ing->locations()->syncWithoutDetaching([$freezer->id => ['quantity' => 5.0]]);
 
         $preparation = Preparation::factory()->create(['company_id' => $company->id, 'name' => 'Préparation de viande', 'unit' => 'kg']);
         PreparationEntity::create(['preparation_id' => $preparation->id, 'entity_id' => $ing->id, 'entity_type' => Ingredient::class]);
@@ -974,8 +974,8 @@ class PreparationControllerTest extends TestCase
         $location2 = Location::factory()->create(['company_id' => $company->id, 'name' => 'Réserve 2']);
         $destination = Location::factory()->create(['company_id' => $company->id, 'name' => 'Cuisine']);
 
-        $ing->locations()->updateExistingPivot($location1->id, ['quantity' => 5.0]);
-        $ing->locations()->updateExistingPivot($location2->id, ['quantity' => 3.0]);
+        $ing->locations()->syncWithoutDetaching([$location1->id => ['quantity' => 5.0]]);
+        $ing->locations()->syncWithoutDetaching([$location2->id => ['quantity' => 3.0]]);
 
         $preparation = Preparation::factory()->create(['company_id' => $company->id, 'name' => 'Simple preparation', 'unit' => 'kg']);
         PreparationEntity::create(['preparation_id' => $preparation->id, 'entity_id' => $ing->id, 'entity_type' => Ingredient::class]);
@@ -1010,13 +1010,13 @@ class PreparationControllerTest extends TestCase
         $source = Location::factory()->create(['company_id' => $company->id, 'name' => 'Réserve']);
         $destination = Location::factory()->create(['company_id' => $company->id, 'name' => 'Cuisine']);
 
-        $ing->locations()->updateExistingPivot($source->id, ['quantity' => 10.0]);
+        $ing->locations()->syncWithoutDetaching([$source->id => ['quantity' => 10.0]]);
 
         $preparation = Preparation::factory()->create(['company_id' => $company->id, 'name' => 'Simple preparation', 'unit' => 'kg']);
         PreparationEntity::create(['preparation_id' => $preparation->id, 'entity_id' => $ing->id, 'entity_type' => Ingredient::class]);
 
         // quantité initiale
-        $preparation->locations()->updateExistingPivot($destination->id, ['quantity' => 1.5]);
+        $preparation->locations()->syncWithoutDetaching([$destination->id => ['quantity' => 1.5]]);
 
         $payload = [
             'quantity' => 2.5,

--- a/tests/Feature/QuantityAdjustmentTest.php
+++ b/tests/Feature/QuantityAdjustmentTest.php
@@ -32,7 +32,7 @@ class QuantityAdjustmentTest extends TestCase
             'company_id' => $company->id,
             'category_id' => $category->id,
         ]);
-        $ingredient->locations()->updateExistingPivot($location->id, ['quantity' => 5]);
+        $ingredient->locations()->syncWithoutDetaching([$location->id => ['quantity' => 5]]);
 
         $this->actingAs($user)
             ->postJson("/api/ingredients/{$ingredient->id}/add-quantity", [
@@ -84,7 +84,7 @@ class QuantityAdjustmentTest extends TestCase
             'company_id' => $company->id,
             'category_id' => $category->id,
         ]);
-        $ingredient->locations()->updateExistingPivot($location->id, ['quantity' => 5]);
+        $ingredient->locations()->syncWithoutDetaching([$location->id => ['quantity' => 5]]);
 
         $this->actingAs($user)
             ->postJson("/api/ingredients/{$ingredient->id}/add-quantity", [
@@ -103,7 +103,7 @@ class QuantityAdjustmentTest extends TestCase
         $user = User::factory()->create(['company_id' => $company->id]);
         $location = Location::factory()->create(['company_id' => $company->id]);
         $ingredient = Ingredient::factory()->create(['company_id' => $company->id]);
-        $ingredient->locations()->updateExistingPivot($location->id, ['quantity' => 5]);
+        $ingredient->locations()->syncWithoutDetaching([$location->id => ['quantity' => 5]]);
 
         $this->actingAs($user)
             ->postJson("/api/ingredients/{$ingredient->id}/remove-quantity", [
@@ -126,7 +126,7 @@ class QuantityAdjustmentTest extends TestCase
         $user = User::factory()->create(['company_id' => $company->id]);
         $location = Location::factory()->create(['company_id' => $company->id]);
         $preparation = Preparation::factory()->create(['company_id' => $company->id]);
-        $preparation->locations()->updateExistingPivot($location->id, ['quantity' => 2]);
+        $preparation->locations()->syncWithoutDetaching([$location->id => ['quantity' => 2]]);
 
         $this->actingAs($user)
             ->postJson("/api/preparations/{$preparation->id}/add-quantity", [
@@ -149,7 +149,7 @@ class QuantityAdjustmentTest extends TestCase
         $user = User::factory()->create(['company_id' => $company->id]);
         $location = Location::factory()->create(['company_id' => $company->id]);
         $preparation = Preparation::factory()->create(['company_id' => $company->id]);
-        $preparation->locations()->updateExistingPivot($location->id, ['quantity' => 3]);
+        $preparation->locations()->syncWithoutDetaching([$location->id => ['quantity' => 3]]);
 
         $this->actingAs($user)
             ->postJson("/api/preparations/{$preparation->id}/remove-quantity", [
@@ -179,8 +179,8 @@ class QuantityAdjustmentTest extends TestCase
             'company_id' => $company->id,
             'category_id' => $category->id,
         ]);
-        $ingredient->locations()->updateExistingPivot($from->id, ['quantity' => 5]);
-        $ingredient->locations()->updateExistingPivot($to->id, ['quantity' => 1]);
+        $ingredient->locations()->syncWithoutDetaching([$from->id => ['quantity' => 5]]);
+        $ingredient->locations()->syncWithoutDetaching([$to->id => ['quantity' => 1]]);
         app(\App\Services\PerishableService::class)->add($ingredient->id, $from->id, $company->id, 5);
 
         $this->actingAs($user)
@@ -237,8 +237,8 @@ class QuantityAdjustmentTest extends TestCase
         $from = Location::factory()->create(['company_id' => $company->id]);
         $to = Location::factory()->create(['company_id' => $company->id]);
         $preparation = Preparation::factory()->create(['company_id' => $company->id]);
-        $preparation->locations()->updateExistingPivot($from->id, ['quantity' => 5]);
-        $preparation->locations()->updateExistingPivot($to->id, ['quantity' => 1]);
+        $preparation->locations()->syncWithoutDetaching([$from->id => ['quantity' => 5]]);
+        $preparation->locations()->syncWithoutDetaching([$to->id => ['quantity' => 1]]);
 
         $this->actingAs($user)
             ->postJson("/api/preparations/{$preparation->id}/move-quantity", [

--- a/tests/Unit/PerishableTest.php
+++ b/tests/Unit/PerishableTest.php
@@ -103,7 +103,7 @@ class PerishableTest extends TestCase
         ]);
         $perishable->forceFill(['created_at' => now()->subHours(2), 'updated_at' => now()->subHours(2)])->save();
 
-        $ingredient->locations()->updateExistingPivot($location->id, ['quantity' => 4]);
+        $ingredient->locations()->syncWithoutDetaching([$location->id => ['quantity' => 4]]);
 
         $this->artisan('perishables:expire')->assertExitCode(0);
 


### PR DESCRIPTION
## Summary
- stop auto-synchronizing ingredients and preparations with zero quantity when creating locations or entities
- adjust tests to explicitly attach stock entries when needed
- run Laravel Pint to ensure consistent formatting in updated models

## Testing
- `./vendor/bin/pint --test`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68b8ab248668832db7dfc70097955168