### PR TITLE
feat: add base unit for ingredients

### DIFF
--- a/app/GraphQL/Resolvers/OpenFoodFactsResolver.php
+++ b/app/GraphQL/Resolvers/OpenFoodFactsResolver.php
@@ -36,10 +36,8 @@ class OpenFoodFactsResolver
                     'code' => $ingredient->barcode,
                     'product_name_fr' => $ingredient->name,
                     'product_quantity' => $ingredient->base_quantity,
-                    'product_quantity_unit' => $ingredient->unit->value,
-                    /**
-                     * @phpstan-ignore-next-line
-                     */
+                    'product_quantity_unit' => $ingredient->base_unit->value,
+                    /** @phpstan-ignore-next-line */
                     'categories' => $ingredient->category->name,
                     'image_front_url' => $ingredient->image_url ? url('/api/image-proxy/'.$ingredient->image_url) : null,
                     'is_already_in_database' => true,

--- a/app/Http/Controllers/IngredientController.php
+++ b/app/Http/Controllers/IngredientController.php
@@ -54,6 +54,7 @@ class IngredientController extends Controller
             'barcode' => 'nullable|string|max:255',
             // ⚠️ non nullable : requis au store
             'base_quantity' => 'required|numeric|min:0',
+            'base_unit' => ['required', 'string', 'max:50', Rule::in(MeasurementUnit::values())],
         ]);
 
         // Vérifier exclusivité : ne pas fournir "image" et "image_url" en même temps
@@ -80,6 +81,7 @@ class IngredientController extends Controller
             'image_url' => $imagePath, // direct si présent
             'barcode' => $request->input('barcode'),
             'base_quantity' => $request->input('base_quantity'), // requis
+            'base_unit' => $request->input('base_unit'),
             'category_id' => $request->input('category_id'),
         ]);
 
@@ -139,6 +141,7 @@ class IngredientController extends Controller
             'barcode' => 'sometimes|nullable|string|max:255',
             // non nullable côté DB, mais en update on n'oblige pas si non fourni
             'base_quantity' => 'sometimes|numeric|min:0',
+            'base_unit' => ['sometimes', 'string', 'max:50', Rule::in(MeasurementUnit::values())],
         ]);
 
         // Vérifier exclusivité : ne pas fournir "image" et "image_url" en même temps
@@ -168,6 +171,9 @@ class IngredientController extends Controller
         }
         if ($request->has('base_quantity')) {
             $ingredient->base_quantity = $request->input('base_quantity');
+        }
+        if ($request->has('base_unit')) {
+            $ingredient->base_unit = $request->input('base_unit');
         }
         $ingredient->save();
 

--- a/app/Models/Ingredient.php
+++ b/app/Models/Ingredient.php
@@ -22,6 +22,7 @@ class Ingredient extends Model
 
     protected $casts = [
         'unit' => MeasurementUnit::class,
+        'base_unit' => MeasurementUnit::class,
     ];
 
     public function company(): BelongsTo

--- a/database/factories/IngredientFactory.php
+++ b/database/factories/IngredientFactory.php
@@ -151,6 +151,7 @@ class IngredientFactory extends Factory
             'name' => $this->faker->randomElement($ingredients).' '.$this->faker->numberBetween(1, 999),
             'unit' => $this->faker->randomElement(MeasurementUnit::values()),
             'base_quantity' => $this->faker->numberBetween(1, 1000),
+            'base_unit' => $this->faker->randomElement(MeasurementUnit::values()),
             'barcode' => $this->faker->unique()->ean13(),
             'company_id' => Company::factory(),
         ];

--- a/database/migrations/2025_07_10_101758_add_base_unit_to_ingredients_table.php
+++ b/database/migrations/2025_07_10_101758_add_base_unit_to_ingredients_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Enums\MeasurementUnit;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('ingredients', function (Blueprint $table) {
+            $table->enum('base_unit', MeasurementUnit::values())
+                ->default(MeasurementUnit::UNIT)
+                ->after('base_quantity');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('ingredients', function (Blueprint $table) {
+            $table->dropColumn('base_unit');
+        });
+    }
+};

--- a/graphql/models/ingredient.graphql
+++ b/graphql/models/ingredient.graphql
@@ -11,6 +11,9 @@ type Ingredient {
     "Quantity for one unit of the ingredient."
     base_quantity: Float!
 
+    "Unit for the base quantity of the ingredient."
+    base_unit: UnitEnum!
+
     quantities: [IngredientQuantity!]!
         @field(
             resolver: "App\\GraphQL\\Resolvers\\IngredientResolver@quantityByLocation"

--- a/tests/Feature/IngredientControllerTest.php
+++ b/tests/Feature/IngredientControllerTest.php
@@ -43,6 +43,7 @@ class IngredientControllerTest extends TestCase
             'name' => 'Tomate',
             'unit' => 'kg',
             'base_quantity' => 1,
+            'base_unit' => 'kg',
             'category_id' => $category->id,
             'quantities' => [['location_id' => $location->id, 'quantity' => 5]],
         ];
@@ -68,6 +69,7 @@ class IngredientControllerTest extends TestCase
             'name' => 'Tomate',
             'unit' => 'kg',
             'base_quantity' => 1,
+            'base_unit' => 'kg',
             'category_id' => $category->id,
             'quantities' => [['location_id' => $location->id, 'quantity' => 5]],
             'image_url' => 'https://example.com/tomate.jpg',
@@ -99,6 +101,7 @@ class IngredientControllerTest extends TestCase
             'name' => 'Tomate',
             'unit' => 'kg',
             'base_quantity' => 1,
+            'base_unit' => 'kg',
             'category_id' => $category->id,
             'quantities' => [
                 ['location_id' => $loc1->id, 'quantity' => 10],
@@ -156,6 +159,7 @@ class IngredientControllerTest extends TestCase
             'name' => 'TomateURL',
             'unit' => 'kg',
             'base_quantity' => 1,
+            'base_unit' => 'kg',
             'category_id' => $category->id,
             'quantities' => [['location_id' => $loc->id, 'quantity' => 3]],
             'image_url' => 'https://example.com/tomate.jpg',
@@ -184,6 +188,7 @@ class IngredientControllerTest extends TestCase
             'name' => 'Tomate',
             'unit' => 'kg',
             'base_quantity' => 1,
+            'base_unit' => 'kg',
             'category_id' => $category->id,
             'quantities' => [['location_id' => $loc->id, 'quantity' => 1]],
             'image_url' => 'https://example.com/t.jpg',
@@ -219,6 +224,7 @@ class IngredientControllerTest extends TestCase
             'name' => 'Tomate',
             'unit' => 'kg',
             'base_quantity' => 1,
+            'base_unit' => 'kg',
             'category_id' => $category->id,
             'quantities' => [['location_id' => $loc->id, 'quantity' => 1]],
             'image_url' => 'https://example.com/t.jpg',
@@ -245,6 +251,7 @@ class IngredientControllerTest extends TestCase
             'name' => 'SansCat',
             'unit' => 'kg',
             'base_quantity' => 1,
+            'base_unit' => 'kg',
             'quantities' => [['location_id' => $loc->id, 'quantity' => 2]],
             'image_url' => 'https://example.com/ok.jpg',
         ];
@@ -272,6 +279,7 @@ class IngredientControllerTest extends TestCase
             'name' => 'BadMime',
             'unit' => 'kg',
             'base_quantity' => 1,
+            'base_unit' => 'kg',
             'category_id' => $category->id,
             'quantities' => [['location_id' => $loc->id, 'quantity' => 1]],
             'image_url' => 'https://example.com/not-image',
@@ -304,6 +312,7 @@ class IngredientControllerTest extends TestCase
             'name' => 'TooBig',
             'unit' => 'kg',
             'base_quantity' => 1,
+            'base_unit' => 'kg',
             'category_id' => $category->id,
             'quantities' => [['location_id' => $loc->id, 'quantity' => 1]],
             'image_url' => 'https://example.com/too-big.jpg',
@@ -326,6 +335,7 @@ class IngredientControllerTest extends TestCase
             'name' => 'Old',
             'unit' => 'kg',
             'base_quantity' => 1,
+            'base_unit' => 'kg',
         ]);
 
         $cat = Category::factory()->create(['company_id' => $company->id, 'name' => 'OldCat']);
@@ -352,7 +362,7 @@ class IngredientControllerTest extends TestCase
         $company = Company::factory()->create();
         $user = User::factory()->create(['company_id' => $company->id]);
 
-        $ing = Ingredient::factory()->create(['company_id' => $company->id, 'base_quantity' => 1]);
+        $ing = Ingredient::factory()->create(['company_id' => $company->id, 'base_quantity' => 1, 'base_unit' => 'kg']);
         $old = Category::factory()->create(['company_id' => $company->id, 'name' => 'OldCat']);
         $ing->category()->associate($old);
         $ing->save();
@@ -374,7 +384,7 @@ class IngredientControllerTest extends TestCase
         $company = Company::factory()->create();
         $user = User::factory()->create(['company_id' => $company->id]);
 
-        $ing = Ingredient::factory()->create(['company_id' => $company->id, 'base_quantity' => 1]);
+        $ing = Ingredient::factory()->create(['company_id' => $company->id, 'base_quantity' => 1, 'base_unit' => 'kg']);
 
         $payload = ['category_id' => null];
 
@@ -390,7 +400,7 @@ class IngredientControllerTest extends TestCase
         $company = Company::factory()->create();
         $user = User::factory()->create(['company_id' => $company->id]);
 
-        $ing = Ingredient::factory()->create(['company_id' => $company->id, 'base_quantity' => 1]);
+        $ing = Ingredient::factory()->create(['company_id' => $company->id, 'base_quantity' => 1, 'base_unit' => 'kg']);
 
         $loc1 = Location::factory()->create(['company_id' => $company->id]);
         $loc2 = Location::factory()->create(['company_id' => $company->id]);
@@ -420,7 +430,7 @@ class IngredientControllerTest extends TestCase
 
         $company = Company::factory()->create();
         $user = User::factory()->create(['company_id' => $company->id]);
-        $ing = Ingredient::factory()->create(['company_id' => $company->id, 'image_url' => null, 'base_quantity' => 1]);
+        $ing = Ingredient::factory()->create(['company_id' => $company->id, 'image_url' => null, 'base_quantity' => 1, 'base_unit' => 'kg']);
 
         $file = UploadedFile::fake()->image('new.jpg', 320, 320);
 
@@ -447,7 +457,7 @@ class IngredientControllerTest extends TestCase
 
         $company = Company::factory()->create();
         $user = User::factory()->create(['company_id' => $company->id]);
-        $ing = Ingredient::factory()->create(['company_id' => $company->id, 'image_url' => null, 'base_quantity' => 1]);
+        $ing = Ingredient::factory()->create(['company_id' => $company->id, 'image_url' => null, 'base_quantity' => 1, 'base_unit' => 'kg']);
 
         $payload = ['image_url' => 'https://example.com/new.png'];
 
@@ -468,7 +478,7 @@ class IngredientControllerTest extends TestCase
 
         $company = Company::factory()->create();
         $user = User::factory()->create(['company_id' => $company->id]);
-        $ing = Ingredient::factory()->create(['company_id' => $company->id, 'base_quantity' => 1]);
+        $ing = Ingredient::factory()->create(['company_id' => $company->id, 'base_quantity' => 1, 'base_unit' => 'kg']);
 
         $file = UploadedFile::fake()->image('x.jpg');
 
@@ -488,7 +498,7 @@ class IngredientControllerTest extends TestCase
     {
         $company = Company::factory()->create();
         $user = User::factory()->create(['company_id' => $company->id]);
-        $ing = Ingredient::factory()->create(['company_id' => $company->id, 'base_quantity' => 1]);
+        $ing = Ingredient::factory()->create(['company_id' => $company->id, 'base_quantity' => 1, 'base_unit' => 'kg']);
 
         $this->actingAs($user)
             ->deleteJson("/api/ingredients/{$ing->id}")
@@ -504,7 +514,7 @@ class IngredientControllerTest extends TestCase
         $company2 = Company::factory()->create();
 
         $user = User::factory()->create(['company_id' => $company1->id]);
-        $ing = Ingredient::factory()->create(['company_id' => $company2->id, 'base_quantity' => 1]);
+        $ing = Ingredient::factory()->create(['company_id' => $company2->id, 'base_quantity' => 1, 'base_unit' => 'kg']);
 
         $this->actingAs($user)
             ->deleteJson("/api/ingredients/{$ing->id}")
@@ -531,6 +541,7 @@ class IngredientControllerTest extends TestCase
             'name' => 'AvecMeta',
             'unit' => 'kg',
             'base_quantity' => 1.25,
+            'base_unit' => 'kg',
             'category_id' => $category->id,
             'quantities' => [['location_id' => $loc->id, 'quantity' => 2]],
             'barcode' => '123456789',
@@ -546,6 +557,7 @@ class IngredientControllerTest extends TestCase
             'id' => $resp['ingredient_id'],
             'barcode' => '123456789',
             'base_quantity' => 1.25,
+            'base_unit' => 'kg',
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- track a base unit for ingredient quantities
- keep OpenFoodFacts DTO unchanged while using base_unit when mapping existing ingredients
- cover base unit usage with tests

## Testing
- `./vendor/bin/pint`
- `./vendor/bin/phpstan analyse --memory-limit=512M`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b8b8970798832da7d51f8da25c57c3