### PR TITLE
feat: allow companies to manage loss reasons

### DIFF
--- a/app/Http/Controllers/LossReasonController.php
+++ b/app/Http/Controllers/LossReasonController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\LossReason;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class LossReasonController extends Controller
+{
+    public function store(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        $validated = $request->validate([
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('loss_reasons')->where(fn ($q) => $q->where('company_id', $user->company_id)),
+            ],
+        ]);
+
+        $reason = LossReason::create([
+            'name' => $validated['name'],
+            'company_id' => $user->company_id,
+        ]);
+
+        return response()->json([
+            'message' => 'Raison créée avec succès',
+            'data' => $reason,
+        ], 201);
+    }
+
+    public function update(Request $request, int $id): JsonResponse
+    {
+        $user = $request->user();
+        $reason = LossReason::where('company_id', $user->company_id)->findOrFail($id);
+
+        $validated = $request->validate([
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('loss_reasons')->where(fn ($q) => $q->where('company_id', $user->company_id))->ignore($reason->id),
+            ],
+        ]);
+
+        $reason->update(['name' => $validated['name']]);
+
+        return response()->json([
+            'message' => 'Raison mise à jour avec succès',
+            'data' => $reason,
+        ]);
+    }
+
+    public function destroy(Request $request, int $id): JsonResponse
+    {
+        $user = $request->user();
+        $reason = LossReason::where('company_id', $user->company_id)->findOrFail($id);
+        $reason->delete();
+
+        return response()->json([
+            'message' => 'Raison supprimée avec succès',
+        ]);
+    }
+}

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -75,6 +75,11 @@ class Company extends Model
         return $this->hasMany(LocationType::class);
     }
 
+    public function lossReasons()
+    {
+        return $this->hasMany(LossReason::class);
+    }
+
     protected static function booted()
     {
         static::created(function ($company) {
@@ -97,6 +102,17 @@ class Company extends Model
                 'name' => 'Réfrigérateur',
                 'location_type_id' => $locationTypes[1]->id,
             ]);
+
+            // Créer les raisons de perte par défaut
+            $company->lossReasons()->createMany(array_map(fn ($name) => ['name' => $name], [
+                'Expired',
+                'Broken',
+                'Spilled',
+                'Contaminated',
+                'Damaged',
+                'Lost',
+                'Other',
+            ]));
         });
     }
 }

--- a/app/Models/LossReason.php
+++ b/app/Models/LossReason.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class LossReason extends Model
+{
+    use HasFactory;
+
+    protected $guarded = ['id'];
+
+    public function company(): BelongsTo
+    {
+        return $this->belongsTo(Company::class);
+    }
+
+    public function scopeForCompany($query)
+    {
+        return $query->where('company_id', auth()->user()->company_id);
+    }
+}

--- a/database/factories/LossReasonFactory.php
+++ b/database/factories/LossReasonFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Company;
+use App\Models\LossReason;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class LossReasonFactory extends Factory
+{
+    protected $model = LossReason::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->unique()->word(),
+            'company_id' => Company::factory(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+    }
+}

--- a/database/migrations/2025_08_11_000000_create_loss_reasons_table.php
+++ b/database/migrations/2025_08_11_000000_create_loss_reasons_table.php
@@ -1,0 +1,61 @@
+<?php
+
+use App\Models\Company;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('loss_reasons', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->foreignId('company_id')->constrained()->onDelete('cascade');
+            $table->timestamps();
+            $table->unique(['company_id', 'name']);
+        });
+
+        $this->createDefaultReasons();
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('loss_reasons');
+    }
+
+    /**
+     * Create default reasons for existing companies.
+     */
+    private function createDefaultReasons(): void
+    {
+        $reasons = [
+            'Expired',
+            'Broken',
+            'Spilled',
+            'Contaminated',
+            'Damaged',
+            'Lost',
+            'Other',
+        ];
+
+        foreach (Company::all() as $company) {
+            foreach ($reasons as $reason) {
+                DB::table('loss_reasons')->insert([
+                    'name' => $reason,
+                    'company_id' => $company->id,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            }
+        }
+    }
+};

--- a/graphql/models/lossReason.graphql
+++ b/graphql/models/lossReason.graphql
@@ -1,0 +1,25 @@
+"""
+Raison de perte prédéfinie pour une entreprise.
+"""
+type LossReason {
+    "Identifiant unique."
+    id: ID!
+
+    "Nom de la raison."
+    name: String!
+
+    "Entreprise associée."
+    company: Company! @belongsTo
+
+    "Date de création."
+    created_at: DateTime!
+
+    "Date de mise à jour."
+    updated_at: DateTime!
+}
+
+extend type Query @guard {
+    "Liste les raisons de perte de l'entreprise actuelle."
+    lossReasons: [LossReason!]! @all(scopes: ["forCompany"])
+}
+

--- a/routes/authed_route.php
+++ b/routes/authed_route.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\IngredientController;
 use App\Http\Controllers\LocationController;
 use App\Http\Controllers\LocationTypeController;
 use App\Http\Controllers\LossController;
+use App\Http\Controllers\LossReasonController;
 use App\Http\Controllers\MenuCommandController;
 use App\Http\Controllers\MenuController;
 use App\Http\Controllers\PreparationController;
@@ -72,6 +73,13 @@ Route::prefix('location')->name('location.')->group(function () {
 Route::prefix('losses')->name('losses.')->group(function () {
     Route::post('/', [LossController::class, 'store'])->name('store');
     Route::delete('/rollback/{loss}', [LossController::class, 'rollback'])->name('rollback');
+});
+
+// Groupe de routes pour les raisons de perte
+Route::prefix('loss-reasons')->name('loss-reasons.')->group(function () {
+    Route::post('/', [LossReasonController::class, 'store'])->name('store');
+    Route::put('/{id}', [LossReasonController::class, 'update'])->name('update');
+    Route::delete('/{id}', [LossReasonController::class, 'destroy'])->name('destroy');
 });
 
 // Routes utilitaires

--- a/tests/Feature/LossReasonControllerTest.php
+++ b/tests/Feature/LossReasonControllerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Company;
+use App\Models\LossReason;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LossReasonControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected Company $company;
+
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->company = Company::factory()->create();
+        $this->user = User::factory()->create(['company_id' => $this->company->id]);
+    }
+
+    public function test_store_creates_reason(): void
+    {
+        $this->actingAs($this->user);
+        $name = 'Reason '.uniqid();
+
+        $response = $this->postJson('/api/loss-reasons', [
+            'name' => $name,
+        ]);
+
+        $response->assertStatus(201)->assertJsonPath('data.name', $name);
+
+        $this->assertDatabaseHas('loss_reasons', [
+            'name' => $name,
+            'company_id' => $this->company->id,
+        ]);
+    }
+
+    public function test_update_changes_reason_name(): void
+    {
+        $this->actingAs($this->user);
+        $reason = LossReason::factory()->create(['company_id' => $this->company->id]);
+        $newName = 'Updated '.uniqid();
+
+        $response = $this->putJson("/api/loss-reasons/{$reason->id}", [
+            'name' => $newName,
+        ]);
+
+        $response->assertStatus(200)->assertJsonPath('data.name', $newName);
+        $this->assertDatabaseHas('loss_reasons', [
+            'id' => $reason->id,
+            'name' => $newName,
+        ]);
+    }
+
+    public function test_destroy_removes_reason(): void
+    {
+        $this->actingAs($this->user);
+        $reason = LossReason::factory()->create(['company_id' => $this->company->id]);
+
+        $response = $this->deleteJson("/api/loss-reasons/{$reason->id}");
+
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('loss_reasons', [
+            'id' => $reason->id,
+        ]);
+    }
+}

--- a/tests/Feature/LossReasonQueryTest.php
+++ b/tests/Feature/LossReasonQueryTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Company;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Tests\TestCase;
+
+class LossReasonQueryTest extends TestCase
+{
+    use MakesGraphQLRequests;
+    use RefreshDatabase;
+
+    public function test_it_lists_company_loss_reasons(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+
+        $response = $this->actingAs($user)->graphQL(/** @lang GraphQL */ '
+            query {
+                lossReasons { id name }
+            }
+        ');
+
+        $response->assertJsonCount(7, 'data.lossReasons');
+        $response->assertJsonFragment(['name' => 'Expired']);
+    }
+}


### PR DESCRIPTION
## Summary
- add loss_reasons table seeded with defaults for each company
- expose company loss reasons via CRUD endpoints and GraphQL query
- cover loss reasons with feature tests

## Testing
- `./vendor/bin/phpstan analyse --memory-limit=2G`
- `./vendor/bin/pint tests/Feature/LossReasonControllerTest.php tests/Feature/LossReasonQueryTest.php app/Http/Controllers/LossReasonController.php app/Models/LossReason.php database/factories/LossReasonFactory.php database/migrations/2025_08_11_000000_create_loss_reasons_table.php routes/authed_route.php`
- `php artisan test tests/Feature/LossReasonControllerTest.php tests/Feature/LossReasonQueryTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b8cfd77224832dabb92b477e0c0dec