### PR TITLE
feat: enhance menu model and order validation

### DIFF
--- a/app/GraphQL/Resolvers/MenuResolver.php
+++ b/app/GraphQL/Resolvers/MenuResolver.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\GraphQL\Resolvers;
+
+use App\Models\Menu;
+
+class MenuResolver
+{
+    public function imageUrl(Menu $menu): ?string
+    {
+        if (! $menu->image_url) {
+            return null;
+        }
+
+        return url('/api/image-proxy/'.$menu->image_url);
+    }
+}

--- a/database/factories/MenuFactory.php
+++ b/database/factories/MenuFactory.php
@@ -15,6 +15,10 @@ class MenuFactory extends Factory
         return [
             'company_id' => Company::factory(),
             'name' => $this->faker->unique()->word(),
+            'description' => $this->faker->sentence(),
+            'image_url' => null,
+            'is_a_la_carte' => $this->faker->boolean(),
+            'is_available' => true,
         ];
     }
 }

--- a/database/migrations/2025_09_15_000000_add_details_to_menus_table.php
+++ b/database/migrations/2025_09_15_000000_add_details_to_menus_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('menus', function (Blueprint $table) {
+            $table->text('description')->nullable()->after('name');
+            $table->string('image_url')->nullable()->after('description');
+            $table->boolean('is_a_la_carte')->default(false)->after('image_url');
+            $table->boolean('is_available')->default(true)->after('is_a_la_carte');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('menus', function (Blueprint $table) {
+            $table->dropColumn(['description', 'image_url', 'is_a_la_carte', 'is_available']);
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,6 +19,7 @@ class DatabaseSeeder extends Seeder
             IngredientSeeder::class,
             PerishableSeeder::class,
             PreparationSeeder::class,
+            MenuSeeder::class,
             StockMovementSeeder::class,
             LossSeeder::class,
         ]);

--- a/database/seeders/MenuSeeder.php
+++ b/database/seeders/MenuSeeder.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\MeasurementUnit;
+use App\Models\Company;
+use App\Models\Ingredient;
+use App\Models\Location;
+use App\Models\Menu;
+use App\Models\MenuItem;
+use Illuminate\Database\Seeder;
+
+class MenuSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $companies = Company::all();
+
+        foreach ($companies as $company) {
+            $ingredients = Ingredient::where('company_id', $company->id)
+                ->whereHas('locations')
+                ->get();
+            $locations = Location::where('company_id', $company->id)->get();
+
+            for ($i = 0; $i < 5; $i++) {
+                $menu = Menu::factory()->create([
+                    'company_id' => $company->id,
+                ]);
+
+                if ($ingredients->count() === 0 || $locations->count() === 0) {
+                    $menu->refreshAvailability();
+
+                    continue;
+                }
+
+                $selected = $ingredients->random(min(2, $ingredients->count()));
+                foreach ($selected as $ingredient) {
+                    $location = $ingredient->locations()->inRandomOrder()->first();
+                    MenuItem::create([
+                        'menu_id' => $menu->id,
+                        'entity_id' => $ingredient->id,
+                        'entity_type' => Ingredient::class,
+                        'quantity' => 1,
+                        'unit' => $ingredient->unit instanceof MeasurementUnit ? $ingredient->unit->value : $ingredient->unit,
+                        'location_id' => $location->id,
+                    ]);
+                }
+
+                $menu->refreshAvailability();
+            }
+        }
+    }
+}

--- a/graphql/models/menu.graphql
+++ b/graphql/models/menu.graphql
@@ -1,6 +1,10 @@
 type Menu {
     id: ID!
     name: String!
+    description: String
+    image_url: String @field(resolver: "App\\GraphQL\\Resolvers\\MenuResolver@imageUrl")
+    is_a_la_carte: Boolean!
+    is_available: Boolean!
     items: [MenuItem!]! @hasMany
     created_at: DateTime!
     updated_at: DateTime!


### PR DESCRIPTION
## Summary
- extend menus with description, image, a-la-carte flag and availability
- add stock-aware availability checks for menus and orders
- seed sample menus and expose new fields via GraphQL
- rename a-la-carte flag to `is_a_la_carte` to match business terminology

## Testing
- `./vendor/bin/pint`
- `./vendor/bin/phpstan analyse --memory-limit=1G`
- `DB_CONNECTION=sqlite DB_DATABASE=database/database.sqlite FILESYSTEM_DISK=local php artisan migrate:fresh --seed` *(fails: Unable to check existence for ingredient images)*
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68b8d949ec30832d8b0c399dba2b5927