### PR TITLE
Add company-specific OpenFoodFacts language option

### DIFF
--- a/app/DTO/OpenFoodFactsDTO.php
+++ b/app/DTO/OpenFoodFactsDTO.php
@@ -32,9 +32,13 @@ class OpenFoodFactsDTO
 
         $this->barcode = $product['code'] ?? '';
 
-        $this->product_name = $product['product_name_fr']
-            ?? $product['product_name']
-            ?? '';
+        $name = $product['product_name_fr'] ?? $product['product_name'] ?? '';
+        $brand = $product['brands'] ?? '';
+
+        $this->product_name = $name;
+        if (! empty($brand)) {
+            $this->product_name .= ' - '.$brand;
+        }
 
         $this->unit = MeasurementUnit::fromOpenFoodFacts($product['product_quantity_unit'] ?? '')->value;
 

--- a/app/DTO/OpenFoodFactsDTO.php
+++ b/app/DTO/OpenFoodFactsDTO.php
@@ -32,7 +32,9 @@ class OpenFoodFactsDTO
 
         $this->barcode = $product['code'] ?? '';
 
-        $name = $product['product_name_fr'] ?? $product['product_name'] ?? '';
+        $language = auth()->user()?->company->open_food_facts_language ?? 'fr';
+
+        $name = $product['product_name_'.$language] ?? $product['product_name'] ?? '';
         $brand = $product['brands'] ?? '';
 
         $this->product_name = $name;

--- a/app/GraphQL/Resolvers/OpenFoodFactsResolver.php
+++ b/app/GraphQL/Resolvers/OpenFoodFactsResolver.php
@@ -31,10 +31,11 @@ class OpenFoodFactsResolver
                 ->first();
 
             if ($ingredient) {
+                $language = $user->company->open_food_facts_language ?? 'fr';
 
                 return new OpenFoodFactsDTO([
                     'code' => $ingredient->barcode,
-                    'product_name_fr' => $ingredient->name,
+                    'product_name_'.$language => $ingredient->name,
                     'product_quantity' => $ingredient->base_quantity,
                     'product_quantity_unit' => $ingredient->base_unit->value,
                     /** @phpstan-ignore-next-line */

--- a/app/Http/Controllers/CompanyController.php
+++ b/app/Http/Controllers/CompanyController.php
@@ -29,10 +29,15 @@ class CompanyController extends Controller
 
         $validated = $request->validate([
             'auto_complete_menu_orders' => 'sometimes|boolean',
+            'open_food_facts_language' => 'sometimes|in:fr,en',
         ]);
 
         if (array_key_exists('auto_complete_menu_orders', $validated)) {
             $company->auto_complete_menu_orders = $validated['auto_complete_menu_orders'];
+        }
+
+        if (array_key_exists('open_food_facts_language', $validated)) {
+            $company->open_food_facts_language = $validated['open_food_facts_language'];
         }
 
         $company->save();
@@ -41,6 +46,7 @@ class CompanyController extends Controller
             'message' => 'Options mises à jour avec succès',
             'data' => [
                 'auto_complete_menu_orders' => $company->auto_complete_menu_orders,
+                'open_food_facts_language' => $company->open_food_facts_language,
             ],
         ]);
     }

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 
 /**
  * @property bool $auto_complete_menu_orders
+ * @property string $open_food_facts_language
  */
 class Company extends Model
 {
@@ -18,6 +19,7 @@ class Company extends Model
 
     protected $casts = [
         'auto_complete_menu_orders' => 'bool',
+        'open_food_facts_language' => 'string',
     ];
 
     /**

--- a/app/Services/OpenFoodFactsService.php
+++ b/app/Services/OpenFoodFactsService.php
@@ -32,8 +32,12 @@ class OpenFoodFactsService
      */
     public function searchByBarcode(string $barcode): ?array
     {
+        $language = auth()->user()?->company->open_food_facts_language ?? 'fr';
+
         $response = $this->client()
-            ->get("/api/v2/product/{$barcode}.json");
+            ->get("/api/v2/product/{$barcode}.json", [
+                'lc' => $language,
+            ]);
 
         if ($response->successful()) {
             return $response->json();
@@ -49,11 +53,14 @@ class OpenFoodFactsService
      */
     public function searchByKeyword(string $query, int $page = 1, int $pageSize = 20): array
     {
+        $language = auth()->user()?->company->open_food_facts_language ?? 'fr';
+
         $response = $this->client()
             ->get('/api/v2/search', [
                 'search_terms' => $query,
                 'page' => $page,
                 'page_size' => $pageSize,
+                'lc' => $language,
             ]);
 
         return $response->successful() ? $response->json() : [];

--- a/config/openfoodfacts.php
+++ b/config/openfoodfacts.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    'base_url' => env('OFF_API_BASE_URL', 'https://fr.openfoodfacts.org'),
+    'base_url' => env('OFF_API_BASE_URL', 'https://world.openfoodfacts.org'),
 ];

--- a/database/factories/CompanyFactory.php
+++ b/database/factories/CompanyFactory.php
@@ -18,6 +18,7 @@ class CompanyFactory extends Factory
     {
         return [
             'name' => $this->faker->unique()->company(),
+            'open_food_facts_language' => 'fr',
         ];
     }
 }

--- a/database/migrations/2025_09_16_000000_add_open_food_facts_language_to_companies_table.php
+++ b/database/migrations/2025_09_16_000000_add_open_food_facts_language_to_companies_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('companies', function (Blueprint $table) {
+            $table->string('open_food_facts_language', 2)->default('fr');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('companies', function (Blueprint $table) {
+            $table->dropColumn('open_food_facts_language');
+        });
+    }
+};

--- a/tests/Feature/CompanyControllerTest.php
+++ b/tests/Feature/CompanyControllerTest.php
@@ -32,4 +32,20 @@ class CompanyControllerTest extends TestCase
 
         $this->assertTrue($company->fresh()->auto_complete_menu_orders);
     }
+
+    /** Vérifie que la langue d'Open Food Facts peut être modifiée. */
+    public function test_update_open_food_facts_language(): void
+    {
+        $company = Company::factory()->create(['open_food_facts_language' => 'fr']);
+        $user = User::factory()->create(['company_id' => $company->id]);
+
+        $this->actingAs($user)
+            ->putJson('/api/company/options', [
+                'open_food_facts_language' => 'en',
+            ])
+            ->assertStatus(200)
+            ->assertJsonPath('data.open_food_facts_language', 'en');
+
+        $this->assertSame('en', $company->fresh()->open_food_facts_language);
+    }
 }

--- a/tests/Feature/OpenFoodFactsDTOTest.php
+++ b/tests/Feature/OpenFoodFactsDTOTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\DTO\OpenFoodFactsDTO;
+use App\Models\Company;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class OpenFoodFactsDTOTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_product_name_uses_company_language(): void
+    {
+        $company = Company::factory()->create(['open_food_facts_language' => 'en']);
+        $user = User::factory()->create(['company_id' => $company->id]);
+        $this->actingAs($user);
+
+        $dto = new OpenFoodFactsDTO([
+            'code' => '123456',
+            'product_name_fr' => 'Nom FR',
+            'product_name_en' => 'Name EN',
+        ]);
+
+        $this->assertSame('Name EN', $dto->product_name);
+    }
+}

--- a/tests/Feature/OpenFoodFactsServiceTest.php
+++ b/tests/Feature/OpenFoodFactsServiceTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Company;
+use App\Models\User;
+use App\Services\OpenFoodFactsService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class OpenFoodFactsServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_service_uses_company_language(): void
+    {
+        Http::fake();
+
+        $company = Company::factory()->create(['open_food_facts_language' => 'en']);
+        $user = User::factory()->create(['company_id' => $company->id]);
+
+        $this->actingAs($user);
+
+        $service = app(OpenFoodFactsService::class);
+        $service->searchByBarcode('123456');
+
+        Http::assertSent(fn ($request) => str_starts_with($request->url(), 'https://world.openfoodfacts.org')
+            && str_contains($request->url(), 'lc=en'));
+    }
+}


### PR DESCRIPTION
## Summary
- allow each company to set OpenFoodFacts display language
- fetch OpenFoodFacts data using company language via `lc` parameter
- cover new setting with tests

## Testing
- `./vendor/bin/pint`
- `./vendor/bin/phpstan analyse --memory-limit=2G`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68bb36c318a8832dbab952aa405ddd48