### PR TITLE
feat(graphql): add me query

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -55,4 +55,9 @@ class User extends Authenticatable
     {
         $this->notify(new ResetPasswordNotification($token));
     }
+
+    public function scopeForCurrentUser($query)
+    {
+        return $query->whereKey(auth()->id())->with('company');
+    }
 }

--- a/graphql/models/user.graphql
+++ b/graphql/models/user.graphql
@@ -39,4 +39,8 @@ extend type Query @guard {
         "Filters by name. Accepts SQL LIKE wildcards `%` and `_`."
         name: String @where(operator: "like")
     ): [User!]! @paginate(defaultCount: 10)
+
+    "The currently authenticated user."
+    me: User!
+        @first(scopes: ["forCurrentUser"])
 }

--- a/tests/Feature/MeQueryTest.php
+++ b/tests/Feature/MeQueryTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Tests\TestCase;
+
+class MeQueryTest extends TestCase
+{
+    use MakesGraphQLRequests;
+    use RefreshDatabase;
+
+    public function test_it_returns_authenticated_user_with_company(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->graphQL(/** @lang GraphQL */ '
+            query {
+                me {
+                    id
+                    name
+                    email
+                    company { id name }
+                }
+            }
+        ');
+
+        $response->assertJson([
+            'data' => [
+                'me' => [
+                    'id' => (string) $user->id,
+                    'name' => $user->name,
+                    'email' => $user->email,
+                    'company' => [
+                        'id' => (string) $user->company->id,
+                        'name' => $user->company->name,
+                    ],
+                ],
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- deliver `me` query via scope instead of custom resolver
- eagerly load company through `forCurrentUser` scope

## Testing
- `./vendor/bin/pint`
- `./vendor/bin/phpstan --memory-limit=2G`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bb3613c4b8832da9fa7462ee63e5f7