### PR TITLE
Use company language for OpenFoodFacts names

### DIFF
--- a/app/DTO/OpenFoodFactsDTO.php
+++ b/app/DTO/OpenFoodFactsDTO.php
@@ -32,7 +32,9 @@ class OpenFoodFactsDTO
 
         $this->barcode = $product['code'] ?? '';
 
-        $name = $product['product_name_fr'] ?? $product['product_name'] ?? '';
+        $language = auth()->user()?->company->open_food_facts_language ?? 'fr';
+
+        $name = $product['product_name_'.$language] ?? $product['product_name'] ?? '';
         $brand = $product['brands'] ?? '';
 
         $this->product_name = $name;

--- a/app/GraphQL/Resolvers/OpenFoodFactsResolver.php
+++ b/app/GraphQL/Resolvers/OpenFoodFactsResolver.php
@@ -31,10 +31,11 @@ class OpenFoodFactsResolver
                 ->first();
 
             if ($ingredient) {
+                $language = $user->company->open_food_facts_language ?? 'fr';
 
                 return new OpenFoodFactsDTO([
                     'code' => $ingredient->barcode,
-                    'product_name_fr' => $ingredient->name,
+                    'product_name_'.$language => $ingredient->name,
                     'product_quantity' => $ingredient->base_quantity,
                     'product_quantity_unit' => $ingredient->base_unit->value,
                     /** @phpstan-ignore-next-line */

--- a/tests/Feature/OpenFoodFactsDTOTest.php
+++ b/tests/Feature/OpenFoodFactsDTOTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\DTO\OpenFoodFactsDTO;
+use App\Models\Company;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class OpenFoodFactsDTOTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_product_name_uses_company_language(): void
+    {
+        $company = Company::factory()->create(['open_food_facts_language' => 'en']);
+        $user = User::factory()->create(['company_id' => $company->id]);
+        $this->actingAs($user);
+
+        $dto = new OpenFoodFactsDTO([
+            'code' => '123456',
+            'product_name_fr' => 'Nom FR',
+            'product_name_en' => 'Name EN',
+        ]);
+
+        $this->assertSame('Name EN', $dto->product_name);
+    }
+}


### PR DESCRIPTION
## Summary
- localize OpenFoodFacts DTO based on company language
- return ingredient names in company language from GraphQL resolver
- test DTO language selection

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68bb3ee345c0832da12b8c412426f244