### PR TITLE
Seed quantities for ingredients and preparations

### DIFF
--- a/database/seeders/IngredientSeeder.php
+++ b/database/seeders/IngredientSeeder.php
@@ -111,8 +111,8 @@ class IngredientSeeder extends Seeder
             ['name' => 'Eau minérale', 'qty' => 50.0, 'unit' => MeasurementUnit::LITRE, 'barcode' => '3274080005003'],
             ['name' => 'Chocolat pâtissier', 'qty' => 4.0, 'unit' => MeasurementUnit::KILOGRAM, 'barcode' => '0643435040823'],
             ['name' => 'Levure boulangère', 'qty' => 500.0, 'unit' => MeasurementUnit::GRAM, 'barcode' => '3564700440377'],
-            // 20 douzaines = 240 unités
-            ['name' => 'Œufs frais', 'qty' => 240.0, 'unit' => MeasurementUnit::UNIT, 'barcode' => '3245412846991'],
+            // Quantités en unité limitées à de petites valeurs
+            ['name' => 'Œufs frais', 'qty' => 3.0, 'unit' => MeasurementUnit::UNIT, 'barcode' => '3245412846991'],
         ];
 
         foreach ($items as $item) {
@@ -177,7 +177,13 @@ class IngredientSeeder extends Seeder
                 $selected = collect($locationIds)->shuffle()->take($take);
                 foreach ($selected as $locId) {
                     // Environ 15 % des entrées auront une quantité nulle (rupture)
-                    $qty = rand(1, 100) <= 15 ? 0 : round(rand(10, 200) / 10, 2);
+                    if (rand(1, 100) <= 15) {
+                        $qty = 0;
+                    } else {
+                        $qty = $ingredient->unit === MeasurementUnit::UNIT
+                            ? round(rand(2, 6) / 2, 2)
+                            : round(rand(10, 200) / 10, 2);
+                    }
                     $ingredient->locations()->attach($locId, ['quantity' => $qty]);
                 }
             }

--- a/database/seeders/PreparationSeeder.php
+++ b/database/seeders/PreparationSeeder.php
@@ -163,7 +163,13 @@ class PreparationSeeder extends Seeder
                 $selected = collect($locationIds)->shuffle()->take($take);
                 foreach ($selected as $locId) {
                     // ~15 % des stocks démarrent à zéro pour simuler une rupture
-                    $qty = rand(1, 100) <= 15 ? 0 : round(rand(10, 150) / 10, 2);
+                    if (rand(1, 100) <= 15) {
+                        $qty = 0;
+                    } else {
+                        $qty = $prep->unit === MeasurementUnit::UNIT
+                            ? round(rand(2, 6) / 2, 2)
+                            : round(rand(10, 150) / 10, 2);
+                    }
                     $prep->locations()->attach($locId, ['quantity' => $qty]);
                 }
             }

--- a/database/seeders/PreparationSeeder.php
+++ b/database/seeders/PreparationSeeder.php
@@ -43,6 +43,8 @@ class PreparationSeeder extends Seeder
     private function seedGoofyTeamSpecificPreparations(Company $company, array $localImages): void
     {
         $categories = Category::where('company_id', $company->id)->pluck('id', 'name')->all();
+        // Liste des emplacements pour pouvoir y attribuer des stocks initiaux
+        $locationIds = $company->locations()->pluck('id')->all();
 
         $recipes = [
             [
@@ -152,6 +154,18 @@ class PreparationSeeder extends Seeder
                     'entity_id' => $ingredientIds[$ingName],
                     'entity_type' => Ingredient::class,
                 ]);
+            }
+
+            // Attache la préparation à quelques emplacements avec quantités
+            if (! empty($locationIds)) {
+                // Sélectionne aléatoirement jusqu'à 3 emplacements de stockage
+                $take = rand(1, min(3, count($locationIds)));
+                $selected = collect($locationIds)->shuffle()->take($take);
+                foreach ($selected as $locId) {
+                    // ~15 % des stocks démarrent à zéro pour simuler une rupture
+                    $qty = rand(1, 100) <= 15 ? 0 : round(rand(10, 150) / 10, 2);
+                    $prep->locations()->attach($locId, ['quantity' => $qty]);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- attach each seeded ingredient to random company locations with quantities (about 15% zero)
- assign random per-location quantities to prepared dishes
- document seeder logic for distributing stocks

## Testing
- `./vendor/bin/pint`
- `./vendor/bin/phpstan analyse --memory-limit=2G`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bb42323480832d80c48f17371de6d5