### PR TITLE
Limit UNIT quantities in seeders

### DIFF
--- a/database/seeders/IngredientSeeder.php
+++ b/database/seeders/IngredientSeeder.php
@@ -111,8 +111,8 @@ class IngredientSeeder extends Seeder
             ['name' => 'Eau minérale', 'qty' => 50.0, 'unit' => MeasurementUnit::LITRE, 'barcode' => '3274080005003'],
             ['name' => 'Chocolat pâtissier', 'qty' => 4.0, 'unit' => MeasurementUnit::KILOGRAM, 'barcode' => '0643435040823'],
             ['name' => 'Levure boulangère', 'qty' => 500.0, 'unit' => MeasurementUnit::GRAM, 'barcode' => '3564700440377'],
-            // 20 douzaines = 240 unités
-            ['name' => 'Œufs frais', 'qty' => 240.0, 'unit' => MeasurementUnit::UNIT, 'barcode' => '3245412846991'],
+            // Quantités en unité limitées à de petites valeurs
+            ['name' => 'Œufs frais', 'qty' => 3.0, 'unit' => MeasurementUnit::UNIT, 'barcode' => '3245412846991'],
         ];
 
         foreach ($items as $item) {
@@ -177,7 +177,13 @@ class IngredientSeeder extends Seeder
                 $selected = collect($locationIds)->shuffle()->take($take);
                 foreach ($selected as $locId) {
                     // Environ 15 % des entrées auront une quantité nulle (rupture)
-                    $qty = rand(1, 100) <= 15 ? 0 : round(rand(10, 200) / 10, 2);
+                    if (rand(1, 100) <= 15) {
+                        $qty = 0;
+                    } else {
+                        $qty = $ingredient->unit === MeasurementUnit::UNIT
+                            ? round(rand(2, 6) / 2, 2)
+                            : round(rand(10, 200) / 10, 2);
+                    }
                     $ingredient->locations()->attach($locId, ['quantity' => $qty]);
                 }
             }

--- a/database/seeders/PreparationSeeder.php
+++ b/database/seeders/PreparationSeeder.php
@@ -163,7 +163,13 @@ class PreparationSeeder extends Seeder
                 $selected = collect($locationIds)->shuffle()->take($take);
                 foreach ($selected as $locId) {
                     // ~15 % des stocks démarrent à zéro pour simuler une rupture
-                    $qty = rand(1, 100) <= 15 ? 0 : round(rand(10, 150) / 10, 2);
+                    if (rand(1, 100) <= 15) {
+                        $qty = 0;
+                    } else {
+                        $qty = $prep->unit === MeasurementUnit::UNIT
+                            ? round(rand(2, 6) / 2, 2)
+                            : round(rand(10, 150) / 10, 2);
+                    }
                     $prep->locations()->attach($locId, ['quantity' => $qty]);
                 }
             }


### PR DESCRIPTION
## Summary
- Restrict UNIT-based ingredient seed quantities to small values
- Apply UNIT-aware quantity limits when seeding stock locations
- Ensure preparations seeded with UNIT units have constrained stock amounts

## Testing
- `./vendor/bin/pint`
- `./vendor/bin/phpstan analyse --memory-limit=2G`


------
https://chatgpt.com/codex/tasks/task_e_68bb46653980832da8ef9fcbe1d8265a