### PR TITLE
Define explicit fillable attributes for models

### DIFF
--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -13,8 +13,9 @@ class Category extends Model
     /** @use HasFactory<\Database\Factories\CategoryFactory> */
     use HasFactory, HasSearchScope;
 
-    protected $guarded = [
-        'id',
+    protected $fillable = [
+        'name',
+        'company_id',
     ];
 
     public function ingredients(): HasMany

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -13,8 +13,10 @@ class Company extends Model
 {
     use HasFactory;
 
-    protected $guarded = [
-        'id',
+    protected $fillable = [
+        'name',
+        'auto_complete_menu_orders',
+        'open_food_facts_language',
     ];
 
     protected $casts = [

--- a/app/Models/Ingredient.php
+++ b/app/Models/Ingredient.php
@@ -16,8 +16,15 @@ class Ingredient extends Model
     /** @use HasFactory<\Database\Factories\IngredientFactory> */
     use HasFactory, HasLosses, HasSearchScope;
 
-    protected $guarded = [
-        'id',
+    protected $fillable = [
+        'name',
+        'company_id',
+        'category_id',
+        'image_url',
+        'unit',
+        'base_quantity',
+        'barcode',
+        'base_unit',
     ];
 
     protected $casts = [

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -27,8 +27,10 @@ class Location extends Model
     /** @use HasFactory<\Database\Factories\LocationFactory> */
     use HasFactory, HasSearchScope;
 
-    protected $guarded = [
-        'id',
+    protected $fillable = [
+        'name',
+        'company_id',
+        'location_type_id',
     ];
 
     public function company()

--- a/app/Models/LocationType.php
+++ b/app/Models/LocationType.php
@@ -17,8 +17,10 @@ class LocationType extends Model
     /** @use HasFactory<\Database\Factories\LocationTypeFactory> */
     use HasFactory, HasSearchScope;
 
-    protected $guarded = [
-        'id',
+    protected $fillable = [
+        'name',
+        'company_id',
+        'is_default',
     ];
 
     /**

--- a/app/Models/LossReason.php
+++ b/app/Models/LossReason.php
@@ -10,7 +10,10 @@ class LossReason extends Model
 {
     use HasFactory;
 
-    protected $guarded = ['id'];
+    protected $fillable = [
+        'name',
+        'company_id',
+    ];
 
     public function company(): BelongsTo
     {

--- a/app/Models/Menu.php
+++ b/app/Models/Menu.php
@@ -15,7 +15,14 @@ class Menu extends Model
 {
     use HasFactory;
 
-    protected $guarded = ['id'];
+    protected $fillable = [
+        'company_id',
+        'name',
+        'description',
+        'image_url',
+        'is_a_la_carte',
+        'is_available',
+    ];
 
     protected $casts = [
         'is_a_la_carte' => 'boolean',

--- a/app/Models/MenuItem.php
+++ b/app/Models/MenuItem.php
@@ -16,7 +16,14 @@ class MenuItem extends Model
 {
     use HasFactory;
 
-    protected $guarded = ['id'];
+    protected $fillable = [
+        'menu_id',
+        'entity_id',
+        'entity_type',
+        'location_id',
+        'quantity',
+        'unit',
+    ];
 
     protected $casts = [
         'unit' => MeasurementUnit::class,

--- a/app/Models/MenuOrder.php
+++ b/app/Models/MenuOrder.php
@@ -13,7 +13,13 @@ class MenuOrder extends Model
 {
     use HasFactory;
 
-    protected $guarded = ['id'];
+    protected $fillable = [
+        'menu_id',
+        'status',
+        'quantity',
+        'created_at',
+        'updated_at',
+    ];
 
     public function menu(): BelongsTo
     {

--- a/app/Models/Preparation.php
+++ b/app/Models/Preparation.php
@@ -17,8 +17,12 @@ class Preparation extends Model
     /** @use HasFactory<\Database\Factories\PreparationFactory> */
     use HasFactory, HasLosses, HasSearchScope;
 
-    protected $guarded = [
-        'id',
+    protected $fillable = [
+        'company_id',
+        'category_id',
+        'name',
+        'unit',
+        'image_url',
     ];
 
     protected $casts = [

--- a/app/Models/PreparationEntity.php
+++ b/app/Models/PreparationEntity.php
@@ -6,7 +6,11 @@ use Illuminate\Database\Eloquent\Model;
 
 class PreparationEntity extends Model
 {
-    protected $guarded = ['id'];
+    protected $fillable = [
+        'preparation_id',
+        'entity_id',
+        'entity_type',
+    ];
 
     public function entity()
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -14,8 +14,11 @@ class User extends Authenticatable
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasApiTokens, HasFactory, Notifiable;
 
-    protected $guarded = [
-        'id',
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+        'company_id',
     ];
 
     /**


### PR DESCRIPTION
## Summary
- Replace `$guarded = ['id']` with explicit `$fillable` arrays in all models
- Allow setting timestamps in `MenuOrder` for stats

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bc922deaf0832d8959e19247084e68