### PR TITLE
Remove remember flag from login credentials

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -30,7 +30,9 @@ class AuthController extends Controller
 
         $remember = $credentials['remember'] ?? false;
 
-        if (Auth::attempt(credentials: $credentials, remember: $remember)) {
+        unset($credentials['remember']);
+
+        if (Auth::attempt($credentials, $remember)) {
 
             $request->session()->regenerate();
 


### PR DESCRIPTION
## Summary
- Avoid passing `remember` field as login credentials before Auth::attempt

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bc989f0d90832d9701fc259c8e50e4