### PR TITLE
chore: rely on eloquent timestamps for menu orders

### DIFF
--- a/app/Models/MenuOrder.php
+++ b/app/Models/MenuOrder.php
@@ -17,9 +17,9 @@ class MenuOrder extends Model
         'menu_id',
         'status',
         'quantity',
-        'created_at',
-        'updated_at',
     ];
+
+    public $timestamps = true;
 
     public function menu(): BelongsTo
     {

--- a/tests/Feature/MenuControllerTest.php
+++ b/tests/Feature/MenuControllerTest.php
@@ -148,7 +148,7 @@ class MenuControllerTest extends TestCase
             ->assertStatus(201);
 
         // Order outside range
-        MenuOrder::create([
+        MenuOrder::forceCreate([
             'menu_id' => $menu->id,
             'status' => 'completed',
             'quantity' => 1,


### PR DESCRIPTION
## Summary
- remove manual created_at/updated_at assignment from menu orders
- let Eloquent manage menu order timestamps
- adjust menu stats test to force create orders with custom timestamps

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bc98a373cc832d8e3513b366fb2124