### PR TITLE
feat: add bulk ingredient creation endpoint

### DIFF
--- a/app/Http/Controllers/IngredientController.php
+++ b/app/Http/Controllers/IngredientController.php
@@ -10,6 +10,7 @@ use App\Services\PerishableService;
 use App\Services\StockService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
 
@@ -109,6 +110,103 @@ class IngredientController extends Controller
         return response()->json([
             'message' => 'Ingredient created successfully',
             'ingredient_id' => $ingredient->id,
+        ], 201);
+    }
+
+    /**
+     * Cas métier : Création de plusieurs ingrédients en une seule requête.
+     *
+     * Cette méthode applique les mêmes validations et logique métier que la
+     * méthode store() mais pour un tableau d'ingrédients. Chaque entrée doit
+     * respecter les mêmes règles (image ou image_url, quantités, etc.).
+     */
+    public function bulkStore(Request $request, ImageService $imageService)
+    {
+        $user = auth()->user();
+
+        $request->validate([
+            'ingredients' => 'required|array|min:1',
+            'ingredients.*.name' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('ingredients')->where(function ($query) use ($user) {
+                    return $query->where('company_id', $user->company_id);
+                }),
+            ],
+            'ingredients.*.unit' => ['required', 'string', 'max:50', Rule::in(MeasurementUnit::values())],
+            'ingredients.*.image' => 'nullable|image|max:2048|required_without:ingredients.*.image_url',
+            'ingredients.*.image_url' => 'nullable|url|required_without:ingredients.*.image',
+            'ingredients.*.category_id' => [
+                'required',
+                Rule::exists('categories', 'id')->where(fn ($q) => $q->where('company_id', $user->company_id)),
+            ],
+            'ingredients.*.quantities' => 'required|array|min:1',
+            'ingredients.*.quantities.*.quantity' => 'required|numeric|min:0',
+            'ingredients.*.quantities.*.location_id' => [
+                'required',
+                Rule::exists('locations', 'id')->where(fn ($q) => $q->where('company_id', $user->company_id)),
+            ],
+            'ingredients.*.barcode' => 'nullable|string|max:255',
+            'ingredients.*.base_quantity' => 'required|numeric|min:0',
+            'ingredients.*.base_unit' => ['required', 'string', 'max:50', Rule::in(MeasurementUnit::values())],
+        ]);
+
+        $createdIds = DB::transaction(function () use ($request, $user, $imageService) {
+            $ids = [];
+
+            foreach ($request->input('ingredients') as $index => $data) {
+                // Vérifier exclusivité image / image_url
+                if (isset($data['image']) && ! empty($data['image']) && ! empty($data['image_url'])) {
+                    throw ValidationException::withMessages([
+                        "ingredients.$index.image" => 'Ne fournissez pas "image" et "image_url" en même temps.',
+                        "ingredients.$index.image_url" => 'Ne fournissez pas "image" et "image_url" en même temps.',
+                    ]);
+                }
+
+                $imagePath = null;
+                if (! empty($data['image'])) {
+                    $imagePath = $imageService->store($data['image'], 'ingredients');
+                } elseif (! empty($data['image_url'])) {
+                    $imagePath = $imageService->storeFromUrl($data['image_url'], 'ingredients');
+                }
+
+                $ingredient = Ingredient::create([
+                    'name' => $data['name'],
+                    'unit' => $data['unit'],
+                    'company_id' => $user->company_id,
+                    'image_url' => $imagePath,
+                    'barcode' => $data['barcode'] ?? null,
+                    'base_quantity' => $data['base_quantity'],
+                    'base_unit' => $data['base_unit'],
+                    'category_id' => $data['category_id'],
+                ]);
+
+                foreach ($data['quantities'] as $i => $quantityData) {
+                    $locationId = $quantityData['location_id'];
+
+                    if (! Location::where('id', $locationId)->where('company_id', $user->company_id)->exists()) {
+                        throw ValidationException::withMessages([
+                            "ingredients.$index.quantities.$i.location_id" => 'Invalid location.',
+                        ]);
+                    }
+
+                    $ingredient->locations()->syncWithoutDetaching([
+                        $locationId => [
+                            'quantity' => $quantityData['quantity'],
+                        ],
+                    ]);
+                }
+
+                $ids[] = $ingredient->id;
+            }
+
+            return $ids;
+        });
+
+        return response()->json([
+            'message' => 'Ingredients created successfully',
+            'ingredient_ids' => $createdIds,
         ], 201);
     }
 

--- a/routes/authed_route.php
+++ b/routes/authed_route.php
@@ -46,6 +46,7 @@ Route::prefix('preparations')->name('preparations.')->group(function () {
 
 // Groupe de routes pour les ingrédients
 Route::prefix('ingredients')->name('ingredients.')->group(function () {
+    Route::post('/bulk', [IngredientController::class, 'bulkStore'])->name('bulk-store');
     Route::post('/', [IngredientController::class, 'store'])->name('store');
     Route::put('/{ingredient}', [IngredientController::class, 'update'])->name('update');
     Route::delete('/{ingredient}', [IngredientController::class, 'destroy'])->name('destroy');

--- a/tests/Feature/IngredientControllerTest.php
+++ b/tests/Feature/IngredientControllerTest.php
@@ -174,6 +174,107 @@ class IngredientControllerTest extends TestCase
         $this->assertTrue(Storage::disk('s3')->exists($ingredient->image_url));
     }
 
+    /** Création multiple d'ingrédients via endpoint bulk. */
+    public function test_it_creates_multiple_ingredients_at_once(): void
+    {
+        Storage::fake('s3');
+
+        $imageBytes = random_bytes(1280);
+        Http::fake([
+            'example.com/*' => Http::response($imageBytes, 200, [
+                'Content-Type' => 'image/jpeg',
+                'Content-Length' => strlen($imageBytes),
+            ]),
+        ]);
+
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+        $loc = Location::factory()->create(['company_id' => $company->id]);
+        $category = Category::factory()->create(['company_id' => $company->id]);
+
+        $payload = [
+            'ingredients' => [
+                [
+                    'name' => 'TomateBulk',
+                    'unit' => 'kg',
+                    'base_quantity' => 1,
+                    'base_unit' => 'kg',
+                    'category_id' => $category->id,
+                    'quantities' => [['location_id' => $loc->id, 'quantity' => 5]],
+                    'image_url' => 'https://example.com/tomate1.jpg',
+                ],
+                [
+                    'name' => 'OignonBulk',
+                    'unit' => 'kg',
+                    'base_quantity' => 2,
+                    'base_unit' => 'kg',
+                    'category_id' => $category->id,
+                    'quantities' => [['location_id' => $loc->id, 'quantity' => 7]],
+                    'image_url' => 'https://example.com/oignon.jpg',
+                ],
+            ],
+        ];
+
+        $resp = $this->actingAs($user)
+            ->postJson('/api/ingredients/bulk', $payload)
+            ->assertStatus(201)
+            ->json();
+
+        $this->assertCount(2, $resp['ingredient_ids']);
+        $this->assertDatabaseHas('ingredients', ['name' => 'TomateBulk']);
+        $this->assertDatabaseHas('ingredients', ['name' => 'OignonBulk']);
+    }
+
+    /** Vérifie que la création multiple est annulée si un ingrédient échoue. */
+    public function test_bulk_creation_rolls_back_when_one_fails(): void
+    {
+        Storage::fake('s3');
+        Http::fake([
+            'example.com/good.jpg' => Http::response(random_bytes(64), 200, [
+                'Content-Type' => 'image/jpeg',
+            ]),
+            'example.com/not-image' => Http::response('<html></html>', 200, [
+                'Content-Type' => 'text/html',
+            ]),
+        ]);
+
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+        $loc = Location::factory()->create(['company_id' => $company->id]);
+        $category = Category::factory()->create(['company_id' => $company->id]);
+
+        $payload = [
+            'ingredients' => [
+                [
+                    'name' => 'TomateRollback',
+                    'unit' => 'kg',
+                    'base_quantity' => 1,
+                    'base_unit' => 'kg',
+                    'category_id' => $category->id,
+                    'quantities' => [['location_id' => $loc->id, 'quantity' => 5]],
+                    'image_url' => 'https://example.com/good.jpg',
+                ],
+                [
+                    'name' => 'OignonRollback',
+                    'unit' => 'kg',
+                    'base_quantity' => 2,
+                    'base_unit' => 'kg',
+                    'category_id' => $category->id,
+                    'quantities' => [['location_id' => $loc->id, 'quantity' => 7]],
+                    // URL qui renvoie un contenu non image pour déclencher une ValidationException après création du premier ingrédient
+                    'image_url' => 'https://example.com/not-image',
+                ],
+            ],
+        ];
+
+        $this->actingAs($user)
+            ->postJson('/api/ingredients/bulk', $payload)
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['image_url']);
+
+        $this->assertDatabaseCount('ingredients', 0);
+    }
+
     /** Unicité du nom par société : échec même nom dans même company. */
     public function test_it_enforces_unique_name_per_company(): void
     {


### PR DESCRIPTION
## Summary
- allow creating several ingredients at once
- ensure bulk creation runs inside a transaction
- test rollback when one ingredient fails

## Testing
- `vendor/bin/pint app/Http/Controllers/IngredientController.php tests/Feature/IngredientControllerTest.php`
- `vendor/bin/phpstan --memory-limit=512M`
- `vendor/bin/phpunit tests/Feature/IngredientControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68bca17075bc832daf0ea279a7a0b112