### PR TITLE
feat: add bulk ingredient creation endpoint

### DIFF
--- a/routes/authed_route.php
+++ b/routes/authed_route.php
@@ -46,6 +46,7 @@ Route::prefix('preparations')->name('preparations.')->group(function () {
 
 // Groupe de routes pour les ingrédients
 Route::prefix('ingredients')->name('ingredients.')->group(function () {
+    Route::post('/bulk', [IngredientController::class, 'bulkStore'])->name('bulk-store');
     Route::post('/', [IngredientController::class, 'store'])->name('store');
     Route::put('/{ingredient}', [IngredientController::class, 'update'])->name('update');
     Route::delete('/{ingredient}', [IngredientController::class, 'destroy'])->name('destroy');


### PR DESCRIPTION
## Summary
- allow creating several ingredients at once
- ensure bulk creation runs inside a transaction
- test rollback when one ingredient fails
- validate duplicate names in bulk payload

## Testing
- `vendor/bin/pint app/Http/Controllers/IngredientController.php tests/Feature/IngredientControllerTest.php`
- `vendor/bin/phpstan --memory-limit=512M`
- `vendor/bin/phpunit tests/Feature/IngredientControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68bca17075bc832daf0ea279a7a0b112