### PR TITLE
Ensure stock movement is recorded on manual quantity changes

### DIFF
--- a/app/Models/Loss.php
+++ b/app/Models/Loss.php
@@ -87,7 +87,7 @@ class Loss extends Model
 
         $trackable->locations()->updateExistingPivot($location->id, ['quantity' => $after]);
 
-        $trackable->recordStockMovement($location, $before, $after, 'loss rollback');
+        $trackable->recordStockMovement($location, $before, $after, 'Loss Rollback');
 
         $this->delete();
     }

--- a/app/Services/StockService.php
+++ b/app/Services/StockService.php
@@ -9,9 +9,9 @@ use Illuminate\Support\Facades\DB;
 
 class StockService
 {
-    public const DEFAULT_ADD_REASON = 'manual addition';
+    public const DEFAULT_ADD_REASON = 'Manual Addition';
 
-    public const DEFAULT_REMOVE_REASON = 'manual withdrawal';
+    public const DEFAULT_REMOVE_REASON = 'Manual Withdrawal';
 
     public function __construct(private PerishableService $perishableService) {}
 

--- a/tests/Feature/LossTrackingTest.php
+++ b/tests/Feature/LossTrackingTest.php
@@ -184,6 +184,6 @@ class LossTrackingTest extends TestCase
         $movements = StockMovement::where('trackable_id', $this->ingredient->id)->get();
         $this->assertCount(2, $movements);
         $this->assertEquals('Oubli', $movements->firstWhere('type', 'withdrawal')->reason);
-        $this->assertEquals('loss rollback', $movements->firstWhere('type', 'addition')->reason);
+        $this->assertEquals('Loss Rollback', $movements->firstWhere('type', 'addition')->reason);
     }
 }


### PR DESCRIPTION
## Summary
- log stock movements when creating ingredients with initial quantities
- record movements during bulk ingredient creation and updates
- track movements when preparation quantities are modified
- clarify stock movement reasons and annotate pivots for static analysis
- capitalize stock movement reasons for front-end display

## Testing
- `./vendor/bin/pint`
- `./vendor/bin/phpstan analyse --memory-limit=2G`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68beaa97e644832da13b325441be39c0