### PR TITLE
feat: log single stock movement for transfers

### DIFF
--- a/tests/Feature/QuantityAdjustmentTest.php
+++ b/tests/Feature/QuantityAdjustmentTest.php
@@ -213,12 +213,10 @@ class QuantityAdjustmentTest extends TestCase
         ]);
 
         $reason = "Moved from {$from->name} to {$to->name}";
-        $this->assertDatabaseHas('stock_movements', [
+        $this->assertDatabaseMissing('stock_movements', [
             'trackable_id' => $ingredient->id,
             'trackable_type' => Ingredient::class,
-            'location_id' => $from->id,
             'type' => 'withdrawal',
-            'reason' => $reason,
         ]);
         $this->assertDatabaseHas('stock_movements', [
             'trackable_id' => $ingredient->id,
@@ -260,12 +258,10 @@ class QuantityAdjustmentTest extends TestCase
         ]);
 
         $reason = "Moved from {$from->name} to {$to->name}";
-        $this->assertDatabaseHas('stock_movements', [
+        $this->assertDatabaseMissing('stock_movements', [
             'trackable_id' => $preparation->id,
             'trackable_type' => Preparation::class,
-            'location_id' => $from->id,
             'type' => 'withdrawal',
-            'reason' => $reason,
         ]);
         $this->assertDatabaseHas('stock_movements', [
             'trackable_id' => $preparation->id,

--- a/tests/Feature/StockServiceTest.php
+++ b/tests/Feature/StockServiceTest.php
@@ -58,10 +58,12 @@ class StockServiceTest extends TestCase
 
         $reason = "Moved from {$from->name} to {$to->name}";
 
-        $withdrawal = StockMovement::where('type', 'withdrawal')->first();
-        $this->assertEquals($reason, $withdrawal->reason);
-
-        $addition = StockMovement::where('type', 'addition')->first();
-        $this->assertEquals($reason, $addition->reason);
+        $movement = StockMovement::first();
+        $this->assertNotNull($movement);
+        $this->assertEquals('addition', $movement->type);
+        $this->assertEquals($reason, $movement->reason);
+        $this->assertEquals(0, $movement->quantity_before);
+        $this->assertEquals(2, $movement->quantity_after);
+        $this->assertEquals(1, StockMovement::count());
     }
 }


### PR DESCRIPTION
## Summary
- record one stock movement when moving stock between locations
- automatically generate transfer reason for stock transfers
- update tests for new transfer behavior

## Testing
- `./vendor/bin/pint`
- `./vendor/bin/phpstan --memory-limit=2G`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68beb4d2bad0832dabba3900c434401c