### PR TITLE
feat: track movement type for stock transfers

### DIFF
--- a/app/Services/StockService.php
+++ b/app/Services/StockService.php
@@ -95,6 +95,8 @@ class StockService
                 $fromPivotQuery->decrement('quantity', $quantity);
             }
 
+            $model->recordStockMovement($from, $fromCurrent, $fromNew, $reason, 'movement');
+
             $toPivotQuery = $model->locations()->newPivotStatementForId($to->id);
             $toPivot = $toPivotQuery->lockForUpdate()->first();
             $toCurrent = (float) ($toPivot->quantity ?? 0);
@@ -106,7 +108,7 @@ class StockService
             }
 
             $toNew = $toCurrent + $quantity;
-            $model->recordStockMovement($to, $toCurrent, $toNew, $reason);
+            $model->recordStockMovement($to, $toCurrent, $toNew, $reason, 'movement');
 
             if ($model instanceof Ingredient) {
                 $this->perishableService->remove($model->id, $fromLocationId, $companyId, $quantity);

--- a/app/Traits/HasStockMovements.php
+++ b/app/Traits/HasStockMovements.php
@@ -24,9 +24,10 @@ trait HasStockMovements
      * @param  float  $quantityBefore  Quantité avant le mouvement
      * @param  float  $quantityAfter  Quantité après le mouvement
      * @param  string|null  $reason  Raison du mouvement
+     * @param  string|null  $type  Type de mouvement forcé (addition, withdrawal, movement)
      * @return StockMovement|null Le mouvement créé ou null si pas de différence significative
      */
-    public function recordStockMovement(Location $location, float $quantityBefore, float $quantityAfter, ?string $reason = null): ?StockMovement
+    public function recordStockMovement(Location $location, float $quantityBefore, float $quantityAfter, ?string $reason = null, ?string $type = null): ?StockMovement
     {
 
         // Validation: Les quantités ne doivent pas être négatives
@@ -52,7 +53,7 @@ trait HasStockMovements
             return null;
         }
 
-        $type = $difference > 0 ? 'addition' : 'withdrawal';
+        $type = $type ?? ($difference > 0 ? 'addition' : 'withdrawal');
 
         /** @var StockMovement */
         $stockMovement = $this->stockMovements()->create([

--- a/database/migrations/2025_08_05_203953_create_stock_movements_table.php
+++ b/database/migrations/2025_08_05_203953_create_stock_movements_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->foreignId('location_id')->constrained();
             $table->foreignId('company_id')->constrained();
             $table->foreignId('user_id')->nullable()->constrained();
-            $table->enum('type', ['addition', 'withdrawal'])->comment('Type de mouvement: ajout ou retrait');
+            $table->enum('type', ['addition', 'withdrawal', 'movement'])->comment('Type de mouvement: ajout, retrait ou déplacement');
             $table->decimal('quantity', 8, 2);
             $table->decimal('quantity_before', 8, 2)->nullable();
             $table->decimal('quantity_after', 8, 2)->nullable();

--- a/graphql/models/stockMovement.graphql
+++ b/graphql/models/stockMovement.graphql
@@ -18,7 +18,7 @@ type StockMovement {
     "L'utilisateur qui a effectué l'opération."
     user: User @belongsTo
 
-    "Type de mouvement: 'addition' ou 'withdrawal'."
+    "Type de mouvement: 'addition', 'withdrawal' ou 'movement'."
     type: String!
 
     "Raison du mouvement."

--- a/tests/Feature/QuantityAdjustmentTest.php
+++ b/tests/Feature/QuantityAdjustmentTest.php
@@ -213,16 +213,18 @@ class QuantityAdjustmentTest extends TestCase
         ]);
 
         $reason = "Moved from {$from->name} to {$to->name}";
-        $this->assertDatabaseMissing('stock_movements', [
+        $this->assertDatabaseHas('stock_movements', [
             'trackable_id' => $ingredient->id,
             'trackable_type' => Ingredient::class,
-            'type' => 'withdrawal',
+            'location_id' => $from->id,
+            'type' => 'movement',
+            'reason' => $reason,
         ]);
         $this->assertDatabaseHas('stock_movements', [
             'trackable_id' => $ingredient->id,
             'trackable_type' => Ingredient::class,
             'location_id' => $to->id,
-            'type' => 'addition',
+            'type' => 'movement',
             'reason' => $reason,
         ]);
     }
@@ -258,16 +260,18 @@ class QuantityAdjustmentTest extends TestCase
         ]);
 
         $reason = "Moved from {$from->name} to {$to->name}";
-        $this->assertDatabaseMissing('stock_movements', [
+        $this->assertDatabaseHas('stock_movements', [
             'trackable_id' => $preparation->id,
             'trackable_type' => Preparation::class,
-            'type' => 'withdrawal',
+            'location_id' => $from->id,
+            'type' => 'movement',
+            'reason' => $reason,
         ]);
         $this->assertDatabaseHas('stock_movements', [
             'trackable_id' => $preparation->id,
             'trackable_type' => Preparation::class,
             'location_id' => $to->id,
-            'type' => 'addition',
+            'type' => 'movement',
             'reason' => $reason,
         ]);
     }

--- a/tests/Feature/StockServiceTest.php
+++ b/tests/Feature/StockServiceTest.php
@@ -58,12 +58,21 @@ class StockServiceTest extends TestCase
 
         $reason = "Moved from {$from->name} to {$to->name}";
 
-        $movement = StockMovement::first();
-        $this->assertNotNull($movement);
-        $this->assertEquals('addition', $movement->type);
-        $this->assertEquals($reason, $movement->reason);
-        $this->assertEquals(0, $movement->quantity_before);
-        $this->assertEquals(2, $movement->quantity_after);
-        $this->assertEquals(1, StockMovement::count());
+        $movements = StockMovement::orderBy('id')->get();
+        $this->assertCount(2, $movements);
+
+        $sourceMovement = $movements->firstWhere('location_id', $from->id);
+        $this->assertNotNull($sourceMovement);
+        $this->assertEquals('movement', $sourceMovement->type);
+        $this->assertEquals($reason, $sourceMovement->reason);
+        $this->assertEquals(5, $sourceMovement->quantity_before);
+        $this->assertEquals(3, $sourceMovement->quantity_after);
+
+        $destMovement = $movements->firstWhere('location_id', $to->id);
+        $this->assertNotNull($destMovement);
+        $this->assertEquals('movement', $destMovement->type);
+        $this->assertEquals($reason, $destMovement->reason);
+        $this->assertEquals(0, $destMovement->quantity_before);
+        $this->assertEquals(2, $destMovement->quantity_after);
     }
 }


### PR DESCRIPTION
## Summary
- allow stock movement logging with explicit type
- record both sides of stock transfers as movement
- document new movement type in schema and migrations

## Testing
- `vendor/bin/pint tests/Feature/QuantityAdjustmentTest.php tests/Feature/StockServiceTest.php app/Traits/HasStockMovements.php app/Services/StockService.php database/migrations/2025_08_05_203953_create_stock_movements_table.php graphql/models/stockMovement.graphql`
- `vendor/bin/phpstan analyse --memory-limit=512M`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bec9d472a4832d9acb56150d561ba4