### PR TITLE
Allow optional ingredient images with placeholder fallback

### DIFF
--- a/app/Services/ImageService.php
+++ b/app/Services/ImageService.php
@@ -105,6 +105,23 @@ class ImageService
         return $path;
     }
 
+    /**
+     * S'assure qu'une image locale (par défaut le placeholder Laravel) est
+     * présente sur S3 et renvoie son chemin.
+     */
+    public function storePlaceholder(string $path = 'private/images/placeholder.svg'): string
+    {
+        if ($this->exists($path)) {
+            return $path;
+        }
+
+        $localPath = storage_path('app/'.$path);
+        $contents = file_get_contents($localPath);
+        Storage::disk('s3')->put($path, $contents);
+
+        return $path;
+    }
+
     public function exists(string $path): bool
     {
         return Storage::disk('s3')->exists($path);


### PR DESCRIPTION
## Summary
- make image and image_url optional and mutually exclusive when creating ingredients
- use placeholder image when none supplied
- add tests for placeholder behaviour in single and bulk creation
- store Laravel placeholder on S3 via ImageService
- add test confirming image proxy serves placeholder image

## Testing
- `./vendor/bin/pint tests/Feature/IngredientControllerTest.php`
- `./vendor/bin/phpstan analyse --memory-limit=1G`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68bf18a203a8832da644f3ca72e7b24d