### PR TITLE
fix: correct CategoryShelfLifeTest namespace

### DIFF
--- a/tests/Feature/CategoryShelfLifeTest.php
+++ b/tests/Feature/CategoryShelfLifeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Feature;
 
 use App\Models\Category;
 use App\Models\Company;


### PR DESCRIPTION
## Summary
- use Tests\Feature namespace for CategoryShelfLifeTest to match file path

## Testing
- `composer dump-autoload`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68c1d5511d6c832d8b7849efbb53cec9