### PR TITLE
Use union type for searchInStock results

### DIFF
--- a/app/GraphQL/Queries/SearchInStockQuery.php
+++ b/app/GraphQL/Queries/SearchInStockQuery.php
@@ -10,22 +10,13 @@ class SearchInStockQuery
     public function resolve(mixed $_, array $args): array
     {
         $keyword = $args['keyword'] ?? '';
-
         $ingredients = Ingredient::forCompany()
             ->search($keyword)
-            ->get()
-            ->map(fn ($ingredient) => [
-                'type' => 'ingredient',
-                'ingredient' => $ingredient,
-            ]);
+            ->get();
 
         $preparations = Preparation::forCompany()
             ->search($keyword)
-            ->get()
-            ->map(fn ($preparation) => [
-                'type' => 'preparation',
-                'preparation' => $preparation,
-            ]);
+            ->get();
 
         return $ingredients->concat($preparations)->all();
     }

--- a/app/GraphQL/Unions/SearchItem.php
+++ b/app/GraphQL/Unions/SearchItem.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\GraphQL\Unions;
+
+use App\Models\Ingredient;
+use App\Models\Preparation;
+use GraphQL\Type\Definition\Type;
+use Nuwave\Lighthouse\Schema\TypeRegistry;
+use Nuwave\Lighthouse\Support\Contracts\UnionType;
+
+class SearchItem implements UnionType
+{
+    public function __construct(private TypeRegistry $typeRegistry) {}
+
+    public function resolveType(mixed $value): Type
+    {
+        return match (true) {
+            $value instanceof Ingredient => $this->typeRegistry->get('Ingredient'),
+            $value instanceof Preparation => $this->typeRegistry->get('Preparation'),
+            default => null,
+        };
+    }
+}

--- a/graphql/models/searchInStock.graphql
+++ b/graphql/models/searchInStock.graphql
@@ -1,8 +1,4 @@
-type SearchItem {
-    type: String!
-    ingredient: Ingredient
-    preparation: Preparation
-}
+union SearchItem @union(resolver: "App\\GraphQL\\Unions\\SearchItem") = Ingredient | Preparation
 
 extend type Query @guard {
     searchInStock(keyword: String!): [SearchItem!]!


### PR DESCRIPTION
## Summary
- return Ingredient or Preparation directly from searchInStock
- add GraphQL union and resolver to distinguish result types

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c34afd8c348327bbc600a1ccaac7be