### PR TITLE
Compute menu availability dynamically

### DIFF
--- a/app/GraphQL/Resolvers/MenuResolver.php
+++ b/app/GraphQL/Resolvers/MenuResolver.php
@@ -14,4 +14,16 @@ class MenuResolver
 
         return url('/api/image-proxy/'.$menu->image_url);
     }
+
+    /**
+     * Resolve menu availability for a given quantity.
+     *
+     * @param  array<string, mixed>  $args
+     */
+    public function available(Menu $menu, array $args): bool
+    {
+        $quantity = $args['quantity'] ?? 1;
+
+        return $menu->hasSufficientStock($quantity);
+    }
 }

--- a/app/Http/Controllers/MenuCommandController.php
+++ b/app/Http/Controllers/MenuCommandController.php
@@ -38,7 +38,7 @@ class MenuCommandController extends Controller
 
         if (! $menu->hasSufficientStock($quantity)) {
             return response()->json([
-                'message' => 'Insufficient stock for this menu order',
+                'message' => 'Menu not available',
             ], 422);
         }
 
@@ -54,7 +54,6 @@ class MenuCommandController extends Controller
 
         if ($status === 'completed') {
             $this->applyOrder($order, $stockService);
-            $menu->refreshAvailability();
         }
 
         return response()->json([
@@ -89,7 +88,6 @@ class MenuCommandController extends Controller
 
         if ($previous !== 'completed' && $order->status === 'completed') {
             $this->applyOrder($order, $stockService);
-            $order->menu->refreshAvailability();
         }
 
         return response()->json([
@@ -114,7 +112,6 @@ class MenuCommandController extends Controller
 
         if ($order->status === 'completed') {
             $this->revertOrder($order, $stockService);
-            $order->menu->refreshAvailability();
         }
 
         $order->status = 'canceled';

--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -115,8 +115,6 @@ class MenuController extends Controller
             ]);
         }
 
-        $menu->refreshAvailability();
-
         return response()->json([
             'message' => 'Menu created',
             'menu' => $menu->load('items.entity', 'categories'),
@@ -315,8 +313,6 @@ class MenuController extends Controller
             }
             $menu->load('items');
         }
-
-        $menu->refreshAvailability();
 
         return response()->json([
             'message' => 'Menu updated',

--- a/database/factories/MenuFactory.php
+++ b/database/factories/MenuFactory.php
@@ -18,7 +18,6 @@ class MenuFactory extends Factory
             'description' => $this->faker->sentence(),
             'image_url' => null,
             'is_a_la_carte' => $this->faker->boolean(),
-            'is_available' => true,
             'type' => $this->faker->randomElement(['entrée', 'plat', 'dessert', 'side']),
             'price' => $this->faker->randomFloat(2, 5, 50),
         ];

--- a/database/migrations/2025_09_18_000000_remove_is_available_from_menus_table.php
+++ b/database/migrations/2025_09_18_000000_remove_is_available_from_menus_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('menus', function (Blueprint $table) {
+            $table->dropColumn('is_available');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('menus', function (Blueprint $table) {
+            $table->boolean('is_available')->default(true)->after('is_a_la_carte');
+        });
+    }
+};

--- a/database/seeders/MenuSeeder.php
+++ b/database/seeders/MenuSeeder.php
@@ -38,8 +38,6 @@ class MenuSeeder extends Seeder
                 }
 
                 if ($ingredients->count() === 0 || $locations->count() === 0) {
-                    $menu->refreshAvailability();
-
                     continue;
                 }
 
@@ -56,7 +54,6 @@ class MenuSeeder extends Seeder
                     ]);
                 }
 
-                $menu->refreshAvailability();
             }
         }
     }

--- a/graphql/models/menu.graphql
+++ b/graphql/models/menu.graphql
@@ -4,7 +4,7 @@ type Menu {
     description: String
     image_url: String @field(resolver: "App\\GraphQL\\Resolvers\\MenuResolver@imageUrl")
     is_a_la_carte: Boolean!
-    is_available: Boolean!
+    available(quantity: Int! = 1): Boolean! @field(resolver: "App\\GraphQL\\Resolvers\\MenuResolver@available")
     type: String!
     price: Float!
     categories: [MenuCategory!]! @belongsToMany
@@ -34,6 +34,8 @@ extend type Query @guard {
         types: [String!] @scope(name: "type")
         "Filtrer par un range de prix [min, max]."
         price_between: [Float!] @scope(name: "priceBetween")
+        "Filtrer par disponibilité."
+        available: Boolean @scope(name: "available")
     ): [Menu!]! @all(scopes: ["forCompany"])
     menu(id: ID! @eq): Menu @find(scopes: ["forCompany"])
 }

--- a/tests/Feature/MenuAvailabilityQueryTest.php
+++ b/tests/Feature/MenuAvailabilityQueryTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Ingredient;
+use App\Models\Location;
+use App\Models\Menu;
+use App\Models\MenuItem;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Tests\TestCase;
+
+class MenuAvailabilityQueryTest extends TestCase
+{
+    use MakesGraphQLRequests;
+    use RefreshDatabase;
+
+    public function test_menu_available_field_reflects_stock_for_requested_quantity(): void
+    {
+        $user = User::factory()->create();
+        $ingredient = Ingredient::factory()->for($user->company)->create();
+        $location = Location::factory()->for($user->company)->create();
+        $ingredient->locations()->sync([$location->id => ['quantity' => 5]]);
+
+        $menu = Menu::factory()->for($user->company)->create();
+        MenuItem::create([
+            'menu_id' => $menu->id,
+            'entity_id' => $ingredient->id,
+            'entity_type' => Ingredient::class,
+            'location_id' => $location->id,
+            'quantity' => 2,
+            'unit' => 'unit',
+        ]);
+
+        $query = /** @lang GraphQL */ '
+            query ($id: ID!, $quantity: Int!) {
+                menu(id: $id) {
+                    available(quantity: $quantity)
+                }
+            }
+        ';
+
+        $this->actingAs($user)
+            ->graphQL($query, ['id' => $menu->id, 'quantity' => 2])
+            ->assertJsonPath('data.menu.available', true);
+
+        $this->actingAs($user)
+            ->graphQL($query, ['id' => $menu->id, 'quantity' => 3])
+            ->assertJsonPath('data.menu.available', false);
+    }
+
+    public function test_menus_query_filters_by_availability(): void
+    {
+        $user = User::factory()->create();
+        $location = Location::factory()->for($user->company)->create();
+
+        $ingredientAvailable = Ingredient::factory()->for($user->company)->create();
+        $ingredientAvailable->locations()->sync([$location->id => ['quantity' => 5]]);
+        $menuAvailable = Menu::factory()->for($user->company)->create();
+        MenuItem::create([
+            'menu_id' => $menuAvailable->id,
+            'entity_id' => $ingredientAvailable->id,
+            'entity_type' => Ingredient::class,
+            'location_id' => $location->id,
+            'quantity' => 1,
+            'unit' => 'unit',
+        ]);
+
+        $ingredientUnavailable = Ingredient::factory()->for($user->company)->create();
+        $ingredientUnavailable->locations()->sync([$location->id => ['quantity' => 0]]);
+        $menuUnavailable = Menu::factory()->for($user->company)->create();
+        MenuItem::create([
+            'menu_id' => $menuUnavailable->id,
+            'entity_id' => $ingredientUnavailable->id,
+            'entity_type' => Ingredient::class,
+            'location_id' => $location->id,
+            'quantity' => 1,
+            'unit' => 'unit',
+        ]);
+
+        $query = /** @lang GraphQL */ '
+            query ($available: Boolean) {
+                menus(available: $available) {
+                    id
+                }
+            }
+        ';
+
+        $this->actingAs($user)
+            ->graphQL($query, ['available' => true])
+            ->assertJsonCount(1, 'data.menus')
+            ->assertJsonFragment(['id' => (string) $menuAvailable->id])
+            ->assertJsonMissing(['id' => (string) $menuUnavailable->id]);
+
+        $this->actingAs($user)
+            ->graphQL($query, ['available' => false])
+            ->assertJsonCount(1, 'data.menus')
+            ->assertJsonFragment(['id' => (string) $menuUnavailable->id])
+            ->assertJsonMissing(['id' => (string) $menuAvailable->id]);
+    }
+}


### PR DESCRIPTION
## Summary
- drop `is_available` column from menus table and treat availability as computed
- expose quantity-aware availability through a GraphQL resolver
- validate menu stock for requested quantity before creating orders
- allow GraphQL menus queries to filter by computed availability
- test GraphQL menu availability field and filter

## Testing
- `./vendor/bin/pint`
- `./vendor/bin/phpstan --memory-limit=2G`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c4830205a8832db906677b4935f9b0