### PR TITLE
feat: add menu order listing

### DIFF
--- a/app/Models/MenuOrder.php
+++ b/app/Models/MenuOrder.php
@@ -25,4 +25,11 @@ class MenuOrder extends Model
     {
         return $this->belongsTo(Menu::class);
     }
+
+    public function scopeForCompany($query)
+    {
+        return $query->whereHas('menu', function ($q) {
+            $q->where('company_id', auth()->user()->company_id);
+        });
+    }
 }

--- a/database/factories/MenuOrderFactory.php
+++ b/database/factories/MenuOrderFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Menu;
+use App\Models\MenuOrder;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class MenuOrderFactory extends Factory
+{
+    protected $model = MenuOrder::class;
+
+    public function definition(): array
+    {
+        return [
+            'menu_id' => Menu::factory(),
+            'status' => $this->faker->randomElement(['pending', 'completed', 'canceled']),
+            'quantity' => $this->faker->numberBetween(1, 5),
+        ];
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -24,6 +24,7 @@ class DatabaseSeeder extends Seeder
             StockMovementSeeder::class,
             LossSeeder::class,
             QuickAccessSeeder::class,
+            MenuOrderSeeder::class,
         ]);
     }
 }

--- a/database/seeders/MenuOrderSeeder.php
+++ b/database/seeders/MenuOrderSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Menu;
+use App\Models\MenuOrder;
+use Illuminate\Database\Seeder;
+
+class MenuOrderSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Menu::all()->each(function (Menu $menu): void {
+            MenuOrder::factory()->count(3)->create([
+                'menu_id' => $menu->id,
+            ]);
+        });
+    }
+}

--- a/graphql/models/menuOrder.graphql
+++ b/graphql/models/menuOrder.graphql
@@ -14,4 +14,14 @@ type MenuOrderStats {
 extend type Query @guard {
     menuOrderStats(start: Date, end: Date): MenuOrderStats!
         @field(resolver: "App\\GraphQL\\Queries\\MenuOrderStatsQuery@resolve")
+
+    menuOrders(
+        status: String @eq
+        orderBy: [OrderByClause!] @orderBy(columnsEnum: MenuOrderOrderByField)
+    ): [MenuOrder!]!
+        @paginate(defaultCount: 10, scopes: ["forCompany"])
+}
+enum MenuOrderOrderByField {
+    STATUS @enum(value: "status")
+    CREATED_AT @enum(value: "created_at")
 }

--- a/tests/Feature/MenuOrderQueryTest.php
+++ b/tests/Feature/MenuOrderQueryTest.php
@@ -22,13 +22,13 @@ class MenuOrderQueryTest extends TestCase
         $user = User::factory()->create(['company_id' => $company->id]);
         $menu = Menu::factory()->create(['company_id' => $company->id]);
 
-        $pending = MenuOrder::forceCreate([
+        $pending = MenuOrder::factory()->create([
             'menu_id' => $menu->id,
             'status' => 'pending',
             'quantity' => 1,
         ]);
 
-        MenuOrder::forceCreate([
+        MenuOrder::factory()->create([
             'menu_id' => $menu->id,
             'status' => 'completed',
             'quantity' => 1,
@@ -64,7 +64,7 @@ class MenuOrderQueryTest extends TestCase
         $user = User::factory()->create(['company_id' => $company->id]);
         $menu = Menu::factory()->create(['company_id' => $company->id]);
 
-        $order1 = MenuOrder::forceCreate([
+        $order1 = MenuOrder::factory()->create([
             'menu_id' => $menu->id,
             'status' => 'pending',
             'quantity' => 1,
@@ -72,7 +72,7 @@ class MenuOrderQueryTest extends TestCase
             'updated_at' => Carbon::parse('2024-01-01'),
         ]);
 
-        $order2 = MenuOrder::forceCreate([
+        $order2 = MenuOrder::factory()->create([
             'menu_id' => $menu->id,
             'status' => 'completed',
             'quantity' => 1,
@@ -80,7 +80,7 @@ class MenuOrderQueryTest extends TestCase
             'updated_at' => Carbon::parse('2024-01-02'),
         ]);
 
-        $order3 = MenuOrder::forceCreate([
+        $order3 = MenuOrder::factory()->create([
             'menu_id' => $menu->id,
             'status' => 'pending',
             'quantity' => 1,

--- a/tests/Feature/MenuOrderQueryTest.php
+++ b/tests/Feature/MenuOrderQueryTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Company;
+use App\Models\Menu;
+use App\Models\MenuOrder;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Tests\TestCase;
+
+class MenuOrderQueryTest extends TestCase
+{
+    use MakesGraphQLRequests;
+    use RefreshDatabase;
+
+    public function test_it_filters_menu_orders_by_status(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+        $menu = Menu::factory()->create(['company_id' => $company->id]);
+
+        $pending = MenuOrder::forceCreate([
+            'menu_id' => $menu->id,
+            'status' => 'pending',
+            'quantity' => 1,
+        ]);
+
+        MenuOrder::forceCreate([
+            'menu_id' => $menu->id,
+            'status' => 'completed',
+            'quantity' => 1,
+        ]);
+
+        $query = /* @lang GraphQL */ '
+            query ($status: String) {
+                menuOrders(status: $status) {
+                    data {
+                        id
+                        status
+                    }
+                }
+            }
+        ';
+
+        $this->actingAs($user)->graphQL($query, ['status' => 'pending'])
+            ->assertJson([
+                'data' => [
+                    'menuOrders' => [
+                        'data' => [
+                            ['id' => (string) $pending->id, 'status' => 'pending'],
+                        ],
+                    ],
+                ],
+            ])
+            ->assertJsonCount(1, 'data.menuOrders.data');
+    }
+
+    public function test_it_orders_menu_orders_by_status_and_creation_date(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+        $menu = Menu::factory()->create(['company_id' => $company->id]);
+
+        $order1 = MenuOrder::forceCreate([
+            'menu_id' => $menu->id,
+            'status' => 'pending',
+            'quantity' => 1,
+            'created_at' => Carbon::parse('2024-01-01'),
+            'updated_at' => Carbon::parse('2024-01-01'),
+        ]);
+
+        $order2 = MenuOrder::forceCreate([
+            'menu_id' => $menu->id,
+            'status' => 'completed',
+            'quantity' => 1,
+            'created_at' => Carbon::parse('2024-01-02'),
+            'updated_at' => Carbon::parse('2024-01-02'),
+        ]);
+
+        $order3 = MenuOrder::forceCreate([
+            'menu_id' => $menu->id,
+            'status' => 'pending',
+            'quantity' => 1,
+            'created_at' => Carbon::parse('2024-01-03'),
+            'updated_at' => Carbon::parse('2024-01-03'),
+        ]);
+
+        $response = $this->actingAs($user)->graphQL(/** @lang GraphQL */ '
+            {
+                menuOrders(orderBy: [{column: STATUS, order: ASC}, {column: CREATED_AT, order: DESC}]) {
+                    data { id }
+                }
+            }
+        ');
+
+        $response->assertJson([
+            'data' => [
+                'menuOrders' => [
+                    'data' => [
+                        ['id' => (string) $order2->id],
+                        ['id' => (string) $order3->id],
+                        ['id' => (string) $order1->id],
+                    ],
+                ],
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- expose `menuOrders` GraphQL query with status filter and sorting
- scope `MenuOrder` model to authenticated company
- cover filtering and sorting with new tests

## Testing
- `./vendor/bin/pint app/Models/MenuOrder.php tests/Feature/MenuOrderQueryTest.php`
- `./vendor/bin/phpstan analyse --memory-limit=1G`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68c6f5d3d2b8832db72f4aa8abec829e