### PR TITLE
[KHP-236] feat: manage rooms and tables

### DIFF
--- a/app/Http/Controllers/RoomController.php
+++ b/app/Http/Controllers/RoomController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Room;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
+
+class RoomController extends Controller
+{
+    /**
+     * Crée une nouvelle salle.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'code' => [
+                'required', 'string', 'max:10',
+                Rule::unique('rooms')->where(fn ($q) => $q->where('company_id', Auth::user()->company_id)),
+            ],
+        ]);
+
+        $room = Room::create([
+            'name' => $validated['name'],
+            'code' => $validated['code'],
+            'company_id' => Auth::user()->company_id,
+        ]);
+
+        return response()->json([
+            'message' => 'Salle créée avec succès',
+            'data' => $room,
+        ], 201);
+    }
+
+    /**
+     * Met à jour une salle existante.
+     */
+    public function update(Request $request, int $id): JsonResponse
+    {
+        $room = Room::forCompany()->findOrFail($id);
+
+        $validated = $request->validate([
+            'name' => 'sometimes|required|string|max:255',
+            'code' => [
+                'sometimes', 'required', 'string', 'max:10',
+                Rule::unique('rooms')->where(fn ($q) => $q->where('company_id', Auth::user()->company_id))->ignore($room->id),
+            ],
+        ]);
+
+        if (isset($validated['name'])) {
+            $room->name = $validated['name'];
+        }
+        if (isset($validated['code'])) {
+            $room->code = $validated['code'];
+        }
+        $room->save();
+
+        return response()->json([
+            'message' => 'Salle mise à jour avec succès',
+            'data' => $room,
+        ]);
+    }
+
+    /**
+     * Supprime une salle.
+     */
+    public function destroy(int $id): JsonResponse
+    {
+        $room = Room::forCompany()->findOrFail($id);
+        $room->delete();
+
+        return response()->json([
+            'message' => 'Salle supprimée avec succès',
+        ]);
+    }
+}

--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Room;
+use App\Models\Table;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
+
+class TableController extends Controller
+{
+    /**
+     * Crée une ou plusieurs tables dans une salle.
+     */
+    public function store(Request $request, int $roomId): JsonResponse
+    {
+        $room = Room::forCompany()->findOrFail($roomId);
+
+        $validated = $request->validate([
+            'label' => [
+                'sometimes', 'string',
+                Rule::unique('tables')->where(fn ($q) => $q->where('room_id', $room->id)),
+            ],
+            'seats' => 'required|integer|min:1',
+            'count' => 'sometimes|integer|min:1',
+        ]);
+
+        if (($validated['count'] ?? 1) > 1 && isset($validated['label'])) {
+            return response()->json([
+                'message' => 'Label non autorisé lors de la création multiple',
+            ], 422);
+        }
+
+        $count = $validated['count'] ?? 1;
+        $tables = [];
+
+        $existingTables = $room->tables()
+            ->where('label', 'like', $room->code.'%')
+            ->get();
+
+        /** @var \Illuminate\Database\Eloquent\Collection<int, Table> $existingTables */
+        $nextIndex = (int) $existingTables
+            ->map(fn (Table $t): int => (int) substr($t->label, strlen($room->code)))
+            ->filter()
+            ->max() + 1;
+        if ($nextIndex < 1) {
+            $nextIndex = 1;
+        }
+
+        for ($i = 0; $i < $count; $i++) {
+            $label = $validated['label'] ?? ($room->code.($nextIndex + $i));
+            $tables[] = Table::create([
+                'label' => $label,
+                'seats' => $validated['seats'],
+                'room_id' => $room->id,
+                'company_id' => Auth::user()->company_id,
+            ]);
+        }
+
+        return response()->json([
+            'message' => 'Tables créées avec succès',
+            'data' => $tables,
+        ], 201);
+    }
+
+    /**
+     * Met à jour une table.
+     */
+    public function update(Request $request, int $roomId, int $tableId): JsonResponse
+    {
+        $room = Room::forCompany()->findOrFail($roomId);
+        $table = Table::where('room_id', $room->id)->where('company_id', $room->company_id)->findOrFail($tableId);
+
+        $validated = $request->validate([
+            'label' => [
+                'sometimes', 'string',
+                Rule::unique('tables')->where(fn ($q) => $q->where('room_id', $room->id))->ignore($table->id),
+            ],
+            'seats' => 'sometimes|integer|min:1',
+        ]);
+
+        if (isset($validated['label'])) {
+            $table->label = $validated['label'];
+        }
+        if (isset($validated['seats'])) {
+            $table->seats = $validated['seats'];
+        }
+        $table->save();
+
+        return response()->json([
+            'message' => 'Table mise à jour avec succès',
+            'data' => $table,
+        ]);
+    }
+
+    /**
+     * Supprime une table.
+     */
+    public function destroy(int $roomId, int $tableId): JsonResponse
+    {
+        $room = Room::forCompany()->findOrFail($roomId);
+        $table = Table::where('room_id', $room->id)->where('company_id', $room->company_id)->findOrFail($tableId);
+        $table->delete();
+
+        return response()->json([
+            'message' => 'Table supprimée avec succès',
+        ]);
+    }
+}

--- a/app/Models/Room.php
+++ b/app/Models/Room.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Room extends Model
+{
+    /** @use HasFactory<\Database\Factories\RoomFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'code',
+        'company_id',
+    ];
+
+    public function company(): BelongsTo
+    {
+        return $this->belongsTo(Company::class);
+    }
+
+    public function tables(): HasMany
+    {
+        return $this->hasMany(Table::class);
+    }
+
+    public function scopeSearch($query, ?string $search)
+    {
+        if (empty($search)) {
+            return $query;
+        }
+
+        return $query->where('name', 'like', '%'.$search.'%');
+    }
+
+    public function scopeForCompany($query)
+    {
+        return $query->where('company_id', auth()->user()->company_id);
+    }
+}

--- a/app/Models/Table.php
+++ b/app/Models/Table.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Table extends Model
+{
+    /** @use HasFactory<\Database\Factories\TableFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'label',
+        'seats',
+        'room_id',
+        'company_id',
+    ];
+
+    public function room(): BelongsTo
+    {
+        return $this->belongsTo(Room::class);
+    }
+
+    public function company(): BelongsTo
+    {
+        return $this->belongsTo(Company::class);
+    }
+
+    public function scopeSearch($query, ?string $search)
+    {
+        if (empty($search)) {
+            return $query;
+        }
+
+        return $query->where('label', 'like', '%'.$search.'%');
+    }
+
+    public function scopeForCompany($query)
+    {
+        return $query->where('company_id', auth()->user()->company_id);
+    }
+}

--- a/database/factories/RoomFactory.php
+++ b/database/factories/RoomFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Company;
+use App\Models\Room;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class RoomFactory extends Factory
+{
+    protected $model = Room::class;
+
+    public function definition(): array
+    {
+        static $counter = 0;
+        $counter++;
+
+        return [
+            'name' => 'Salle '.$counter,
+            'code' => 'R'.$counter,
+            'company_id' => Company::factory(),
+        ];
+    }
+}

--- a/database/factories/TableFactory.php
+++ b/database/factories/TableFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Company;
+use App\Models\Room;
+use App\Models\Table;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TableFactory extends Factory
+{
+    protected $model = Table::class;
+
+    public function definition(): array
+    {
+        return [
+            'label' => 'T'.uniqid(),
+            'seats' => 4,
+            'room_id' => Room::factory(),
+            'company_id' => Company::factory(),
+        ];
+    }
+}

--- a/database/migrations/2025_09_19_000000_create_rooms_table.php
+++ b/database/migrations/2025_09_19_000000_create_rooms_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('rooms', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('code');
+            $table->foreignId('company_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+            $table->unique(['company_id', 'code']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('rooms');
+    }
+};

--- a/database/migrations/2025_09_19_000001_create_tables_table.php
+++ b/database/migrations/2025_09_19_000001_create_tables_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tables', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('room_id')->constrained('rooms')->cascadeOnDelete();
+            $table->foreignId('company_id')->constrained()->cascadeOnDelete();
+            $table->string('label');
+            $table->unsignedInteger('seats');
+            $table->timestamps();
+            $table->unique(['room_id', 'label']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tables');
+    }
+};

--- a/graphql/models/room.graphql
+++ b/graphql/models/room.graphql
@@ -1,0 +1,31 @@
+type Room {
+    "Unique primary key."
+    id: ID!
+
+    name: String!
+    code: String!
+    company: Company! @belongsTo
+    tables: [Table!]! @hasMany
+    created_at: DateTime!
+    updated_at: DateTime!
+}
+
+extend type Query @guard {
+    rooms(
+        search: String @scope(name: "search")
+        code: String @where(key: "code")
+        orderBy: [OrderByClause!] @orderBy(columnsEnum: RoomOrderByField)
+    ): [Room!]! @paginate(defaultCount: 10, scopes: ["forCompany"])
+    room(
+        id: ID @eq @rules(apply: ["prohibits:code", "required_without:code"])
+        code: String @eq @rules(apply: ["prohibits:id", "required_without:id"])
+    ): Room @find(scopes: ["forCompany"])
+}
+
+enum RoomOrderByField {
+    ID @enum(value: "id")
+    NAME @enum(value: "name")
+    CODE @enum(value: "code")
+    CREATED_AT @enum(value: "created_at")
+    UPDATED_AT @enum(value: "updated_at")
+}

--- a/graphql/models/table.graphql
+++ b/graphql/models/table.graphql
@@ -1,0 +1,28 @@
+type Table {
+    "Unique primary key."
+    id: ID!
+
+    label: String!
+    seats: Int!
+    room: Room! @belongsTo
+    created_at: DateTime!
+    updated_at: DateTime!
+}
+
+extend type Query @guard {
+    tables(
+        search: String @scope(name: "search")
+        roomId: ID @where(key: "room_id")
+        orderBy: [OrderByClause!] @orderBy(columnsEnum: TableOrderByField)
+    ): [Table!]! @paginate(defaultCount: 10, scopes: ["forCompany"])
+    table(id: ID! @eq): Table @find(scopes: ["forCompany"])
+}
+
+enum TableOrderByField {
+    ID @enum(value: "id")
+    LABEL @enum(value: "label")
+    SEATS @enum(value: "seats")
+    ROOM_ID @enum(value: "room_id")
+    CREATED_AT @enum(value: "created_at")
+    UPDATED_AT @enum(value: "updated_at")
+}

--- a/routes/authed_route.php
+++ b/routes/authed_route.php
@@ -12,6 +12,8 @@ use App\Http\Controllers\MenuCommandController;
 use App\Http\Controllers\MenuController;
 use App\Http\Controllers\PreparationController;
 use App\Http\Controllers\QuickAccessController;
+use App\Http\Controllers\RoomController;
+use App\Http\Controllers\TableController;
 use App\Http\Controllers\UserController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -123,6 +125,17 @@ Route::prefix('menu-categories')->name('menu-categories.')->group(function () {
     Route::post('/', [MenuCategoryController::class, 'store'])->name('store');
     Route::put('/{id}', [MenuCategoryController::class, 'update'])->name('update');
     Route::delete('/{id}', [MenuCategoryController::class, 'destroy'])->name('destroy');
+});
+
+// Groupe de routes pour les salles et tables
+Route::prefix('rooms')->name('rooms.')->group(function () {
+    Route::post('/', [RoomController::class, 'store'])->name('store');
+    Route::put('/{id}', [RoomController::class, 'update'])->name('update');
+    Route::delete('/{id}', [RoomController::class, 'destroy'])->name('destroy');
+
+    Route::post('/{room}/tables', [TableController::class, 'store'])->name('tables.store');
+    Route::put('/{room}/tables/{table}', [TableController::class, 'update'])->name('tables.update');
+    Route::delete('/{room}/tables/{table}', [TableController::class, 'destroy'])->name('tables.destroy');
 });
 // Groupe de routes pour les Quick Access
 Route::prefix('quick-access')->name('quick-access.')->group(function () {

--- a/tests/Feature/RoomControllerTest.php
+++ b/tests/Feature/RoomControllerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Company;
+use App\Models\Room;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class RoomControllerTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    protected $user;
+
+    protected $company;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->company = Company::factory()->create();
+        $this->user = User::factory()->create([
+            'company_id' => $this->company->id,
+        ]);
+    }
+
+    public function test_store_creates_room()
+    {
+        $this->actingAs($this->user);
+
+        $response = $this->postJson('/api/rooms', [
+            'name' => 'Salle A',
+            'code' => 'A',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.name', 'Salle A')
+            ->assertJsonPath('data.code', 'A');
+
+        $this->assertDatabaseHas('rooms', [
+            'name' => 'Salle A',
+            'code' => 'A',
+            'company_id' => $this->company->id,
+        ]);
+    }
+
+    public function test_update_room()
+    {
+        $this->actingAs($this->user);
+
+        $room = Room::factory()->create([
+            'name' => 'Salle A',
+            'code' => 'A',
+            'company_id' => $this->company->id,
+        ]);
+
+        $response = $this->putJson('/api/rooms/'.$room->id, [
+            'name' => 'Salle B',
+            'code' => 'B',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.name', 'Salle B')
+            ->assertJsonPath('data.code', 'B');
+
+        $this->assertDatabaseHas('rooms', [
+            'id' => $room->id,
+            'name' => 'Salle B',
+            'code' => 'B',
+        ]);
+    }
+
+    public function test_destroy_room()
+    {
+        $this->actingAs($this->user);
+
+        $room = Room::factory()->create([
+            'company_id' => $this->company->id,
+        ]);
+
+        $response = $this->deleteJson('/api/rooms/'.$room->id);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('rooms', [
+            'id' => $room->id,
+        ]);
+    }
+}

--- a/tests/Feature/RoomQueryTest.php
+++ b/tests/Feature/RoomQueryTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Room;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Tests\TestCase;
+
+class RoomQueryTest extends TestCase
+{
+    use MakesGraphQLRequests;
+    use RefreshDatabase;
+
+    public function test_it_lists_rooms_for_company(): void
+    {
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+        Room::factory()->for($user->company)->create(['name' => 'Alpha']);
+        Room::factory()->for($other->company)->create(['name' => 'Beta']);
+
+        $response = $this->actingAs($user)->graphQL(/** @lang GraphQL */ '{
+            rooms {
+                data { name }
+            }
+        }');
+
+        $response->assertJsonCount(1, 'data.rooms.data');
+        $response->assertJsonFragment(['name' => 'Alpha']);
+        $response->assertJsonMissing(['name' => 'Beta']);
+    }
+
+    public function test_it_filters_rooms_by_search(): void
+    {
+        $user = User::factory()->create();
+        Room::factory()->for($user->company)->create(['name' => 'Blue Room']);
+        Room::factory()->for($user->company)->create(['name' => 'Red Room']);
+
+        $query = /** @lang GraphQL */ 'query ($search: String) {
+            rooms(search: $search) {
+                data { name }
+            }
+        }';
+
+        $response = $this->actingAs($user)->graphQL($query, ['search' => 'Blue']);
+
+        $response->assertJsonCount(1, 'data.rooms.data');
+        $response->assertJsonFragment(['name' => 'Blue Room']);
+        $response->assertJsonMissing(['name' => 'Red Room']);
+    }
+
+    public function test_it_filters_rooms_by_code(): void
+    {
+        $user = User::factory()->create();
+        Room::factory()->for($user->company)->create(['code' => 'A']);
+        Room::factory()->for($user->company)->create(['code' => 'B']);
+
+        $query = /** @lang GraphQL */ 'query ($code: String) {
+            rooms(code: $code) {
+                data { code }
+            }
+        }';
+
+        $response = $this->actingAs($user)->graphQL($query, ['code' => 'A']);
+
+        $response->assertJsonCount(1, 'data.rooms.data');
+        $response->assertJsonFragment(['code' => 'A']);
+        $response->assertJsonMissing(['code' => 'B']);
+    }
+
+    public function test_it_orders_rooms_by_name_desc(): void
+    {
+        $user = User::factory()->create();
+        Room::factory()->for($user->company)->create(['name' => 'A']);
+        Room::factory()->for($user->company)->create(['name' => 'B']);
+
+        $response = $this->actingAs($user)->graphQL(/** @lang GraphQL */ '
+            {
+                rooms(orderBy: [{column: NAME, order: DESC}]) {
+                    data { name }
+                }
+            }
+        ');
+
+        $response->assertJsonPath('data.rooms.data.0.name', 'B');
+        $response->assertJsonPath('data.rooms.data.1.name', 'A');
+    }
+
+    public function test_it_fetches_room_by_id(): void
+    {
+        $user = User::factory()->create();
+        $room = Room::factory()->for($user->company)->create();
+
+        $query = /** @lang GraphQL */ 'query ($id: ID!) {
+            room(id: $id) { id }
+        }';
+
+        $response = $this->actingAs($user)->graphQL($query, ['id' => $room->id]);
+
+        $response->assertJsonFragment(['id' => (string) $room->id]);
+    }
+
+    public function test_it_fetches_room_by_code(): void
+    {
+        $user = User::factory()->create();
+        $room = Room::factory()->for($user->company)->create(['code' => 'A']);
+
+        $query = /** @lang GraphQL */ 'query ($code: String!) {
+            room(code: $code) { code }
+        }';
+
+        $response = $this->actingAs($user)->graphQL($query, ['code' => 'A']);
+
+        $response->assertJsonFragment(['code' => 'A']);
+    }
+}

--- a/tests/Feature/TableControllerTest.php
+++ b/tests/Feature/TableControllerTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Company;
+use App\Models\Room;
+use App\Models\Table;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class TableControllerTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    protected $user;
+
+    protected $company;
+
+    protected $room;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->company = Company::factory()->create();
+        $this->user = User::factory()->create(['company_id' => $this->company->id]);
+        $this->room = Room::factory()->create([
+            'company_id' => $this->company->id,
+            'code' => 'A',
+        ]);
+    }
+
+    public function test_store_creates_multiple_tables_with_auto_labels()
+    {
+        $this->actingAs($this->user);
+
+        $response = $this->postJson('/api/rooms/'.$this->room->id.'/tables', [
+            'count' => 3,
+            'seats' => 4,
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonCount(3, 'data')
+            ->assertJsonPath('data.0.label', 'A1')
+            ->assertJsonPath('data.1.label', 'A2')
+            ->assertJsonPath('data.2.label', 'A3');
+
+        $this->assertDatabaseHas('tables', [
+            'room_id' => $this->room->id,
+            'label' => 'A1',
+            'seats' => 4,
+        ]);
+        $this->assertDatabaseHas('tables', [
+            'room_id' => $this->room->id,
+            'label' => 'A3',
+        ]);
+    }
+
+    public function test_update_table()
+    {
+        $this->actingAs($this->user);
+
+        $table = Table::factory()->create([
+            'room_id' => $this->room->id,
+            'company_id' => $this->company->id,
+            'label' => 'A1',
+            'seats' => 2,
+        ]);
+
+        $response = $this->putJson('/api/rooms/'.$this->room->id.'/tables/'.$table->id, [
+            'label' => 'A5',
+            'seats' => 6,
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.label', 'A5')
+            ->assertJsonPath('data.seats', 6);
+
+        $this->assertDatabaseHas('tables', [
+            'id' => $table->id,
+            'label' => 'A5',
+            'seats' => 6,
+        ]);
+    }
+
+    public function test_destroy_table()
+    {
+        $this->actingAs($this->user);
+
+        $table = Table::factory()->create([
+            'room_id' => $this->room->id,
+            'company_id' => $this->company->id,
+        ]);
+
+        $response = $this->deleteJson('/api/rooms/'.$this->room->id.'/tables/'.$table->id);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('tables', [
+            'id' => $table->id,
+        ]);
+    }
+}

--- a/tests/Feature/TableQueryTest.php
+++ b/tests/Feature/TableQueryTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Room;
+use App\Models\Table;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Tests\TestCase;
+
+class TableQueryTest extends TestCase
+{
+    use MakesGraphQLRequests;
+    use RefreshDatabase;
+
+    public function test_it_lists_tables_for_company(): void
+    {
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+        $room = Room::factory()->for($user->company)->create();
+        Table::factory()->for($room)->for($user->company)->create(['label' => 'A1']);
+        Table::factory()->for(Room::factory()->for($other->company))->for($other->company)->create(['label' => 'B1']);
+
+        $response = $this->actingAs($user)->graphQL(/** @lang GraphQL */ '{
+            tables { data { label } }
+        }');
+
+        $response->assertJsonCount(1, 'data.tables.data');
+        $response->assertJsonFragment(['label' => 'A1']);
+        $response->assertJsonMissing(['label' => 'B1']);
+    }
+
+    public function test_it_filters_tables_by_search(): void
+    {
+        $user = User::factory()->create();
+        $room = Room::factory()->for($user->company)->create();
+        Table::factory()->for($room)->for($user->company)->create(['label' => 'T1']);
+        Table::factory()->for($room)->for($user->company)->create(['label' => 'T2']);
+
+        $query = /** @lang GraphQL */ 'query ($search: String) {
+            tables(search: $search) { data { label } }
+        }';
+
+        $response = $this->actingAs($user)->graphQL($query, ['search' => 'T1']);
+
+        $response->assertJsonCount(1, 'data.tables.data');
+        $response->assertJsonFragment(['label' => 'T1']);
+        $response->assertJsonMissing(['label' => 'T2']);
+    }
+
+    public function test_it_filters_tables_by_room_id(): void
+    {
+        $user = User::factory()->create();
+        $roomA = Room::factory()->for($user->company)->create();
+        $roomB = Room::factory()->for($user->company)->create();
+        Table::factory()->for($roomA)->for($user->company)->create(['label' => 'A1']);
+        Table::factory()->for($roomB)->for($user->company)->create(['label' => 'B1']);
+
+        $query = /** @lang GraphQL */ 'query ($roomId: ID) {
+            tables(roomId: $roomId) { data { label } }
+        }';
+
+        $response = $this->actingAs($user)->graphQL($query, ['roomId' => $roomA->id]);
+
+        $response->assertJsonCount(1, 'data.tables.data');
+        $response->assertJsonFragment(['label' => 'A1']);
+        $response->assertJsonMissing(['label' => 'B1']);
+    }
+
+    public function test_it_orders_tables_by_label_desc(): void
+    {
+        $user = User::factory()->create();
+        $room = Room::factory()->for($user->company)->create();
+        Table::factory()->for($room)->for($user->company)->create(['label' => 'A']);
+        Table::factory()->for($room)->for($user->company)->create(['label' => 'B']);
+
+        $response = $this->actingAs($user)->graphQL(/** @lang GraphQL */ '{
+            tables(orderBy: [{column: LABEL, order: DESC}]) { data { label } }
+        }');
+
+        $response->assertJsonPath('data.tables.data.0.label', 'B');
+        $response->assertJsonPath('data.tables.data.1.label', 'A');
+    }
+
+    public function test_it_fetches_table_by_id(): void
+    {
+        $user = User::factory()->create();
+        $room = Room::factory()->for($user->company)->create();
+        $table = Table::factory()->for($room)->for($user->company)->create();
+
+        $query = /** @lang GraphQL */ 'query ($id: ID!) {
+            table(id: $id) { id }
+        }';
+
+        $response = $this->actingAs($user)->graphQL($query, ['id' => $table->id]);
+
+        $response->assertJsonFragment(['id' => (string) $table->id]);
+    }
+}


### PR DESCRIPTION
## Summary
- create rooms and tables models and migrations
- add controllers and routes for room/table management with auto label generation
- expose rooms via GraphQL with search, code filters and sortable fields
- expose tables via GraphQL with label search, room filters and sortable fields
- cover room and table CRUD plus GraphQL queries with tests

## Testing
- `vendor/bin/pint`
- `vendor/bin/phpstan --memory-limit=2G`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68c804461174832daf42a17a4e438784