### PR TITLE
[KHP-236] feat: enable fuzzy search for rooms and tables

### DIFF
--- a/app/Models/Room.php
+++ b/app/Models/Room.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\HasSearchScope;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -10,7 +11,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 class Room extends Model
 {
     /** @use HasFactory<\Database\Factories\RoomFactory> */
-    use HasFactory;
+    use HasFactory, HasSearchScope;
 
     protected $fillable = [
         'name',
@@ -26,15 +27,6 @@ class Room extends Model
     public function tables(): HasMany
     {
         return $this->hasMany(Table::class);
-    }
-
-    public function scopeSearch($query, ?string $search)
-    {
-        if (empty($search)) {
-            return $query;
-        }
-
-        return $query->where('name', 'like', '%'.$search.'%');
     }
 
     public function scopeForCompany($query)

--- a/app/Models/Table.php
+++ b/app/Models/Table.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\HasSearchScope;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -9,7 +10,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class Table extends Model
 {
     /** @use HasFactory<\Database\Factories\TableFactory> */
-    use HasFactory;
+    use HasFactory, HasSearchScope;
 
     protected $fillable = [
         'label',
@@ -17,6 +18,8 @@ class Table extends Model
         'room_id',
         'company_id',
     ];
+
+    protected string $searchColumn = 'label';
 
     public function room(): BelongsTo
     {
@@ -26,15 +29,6 @@ class Table extends Model
     public function company(): BelongsTo
     {
         return $this->belongsTo(Company::class);
-    }
-
-    public function scopeSearch($query, ?string $search)
-    {
-        if (empty($search)) {
-            return $query;
-        }
-
-        return $query->where('label', 'like', '%'.$search.'%');
     }
 
     public function scopeForCompany($query)

--- a/app/Traits/HasSearchScope.php
+++ b/app/Traits/HasSearchScope.php
@@ -18,16 +18,27 @@ trait HasSearchScope
 
         $clean = Str::lower($search);
 
+        /** @phpstan-ignore-next-line property_exists will evaluate to true on models defining the property */
+        $column = property_exists($this, 'searchColumn') ? $this->searchColumn : 'name';
+
+        /** @var \Illuminate\Database\Connection $connection */
+        $connection = $query->getConnection();
+
+        // Fallback simple LIKE for SQLite, otherwise use trigram similarity
+        if ($connection->getDriverName() === 'sqlite') {
+            return $query->where($column, 'like', '%'.$clean.'%');
+        }
+
         // Seuil plus permissif : 0.1 (au lieu de 0.3)
         $threshold = 0.1;
 
         return $query
             ->whereRaw(
-                'similarity(unaccent(lower(name)), unaccent(lower(?))) > ?',
+                "similarity(unaccent(lower({$column})), unaccent(lower(?))) > ?",
                 [$clean, $threshold]
             )
             ->orderByRaw(
-                'similarity(unaccent(lower(name)), unaccent(lower(?))) DESC',
+                "similarity(unaccent(lower({$column})), unaccent(lower(?))) DESC",
                 [$clean]
             );
     }

--- a/tests/Feature/RoomQueryTest.php
+++ b/tests/Feature/RoomQueryTest.php
@@ -43,7 +43,7 @@ class RoomQueryTest extends TestCase
             }
         }';
 
-        $response = $this->actingAs($user)->graphQL($query, ['search' => 'Blue']);
+        $response = $this->actingAs($user)->graphQL($query, ['search' => 'blu']);
 
         $response->assertJsonCount(1, 'data.rooms.data');
         $response->assertJsonFragment(['name' => 'Blue Room']);

--- a/tests/Feature/TableQueryTest.php
+++ b/tests/Feature/TableQueryTest.php
@@ -42,7 +42,7 @@ class TableQueryTest extends TestCase
             tables(search: $search) { data { label } }
         }';
 
-        $response = $this->actingAs($user)->graphQL($query, ['search' => 'T1']);
+        $response = $this->actingAs($user)->graphQL($query, ['search' => 't1']);
 
         $response->assertJsonCount(1, 'data.tables.data');
         $response->assertJsonFragment(['label' => 'T1']);

--- a/tests/Unit/HasSearchScopeTest.php
+++ b/tests/Unit/HasSearchScopeTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Traits\HasSearchScope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class HasSearchScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('search_scope_defaults', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+        });
+
+        Schema::create('search_scope_customs', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('label');
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::drop('search_scope_defaults');
+        Schema::drop('search_scope_customs');
+
+        parent::tearDown();
+    }
+
+    public function test_search_scope_uses_name_by_default(): void
+    {
+        SearchScopeDefaultModel::create(['name' => 'Alpha']);
+        SearchScopeDefaultModel::create(['name' => 'Beta']);
+
+        $results = SearchScopeDefaultModel::search('alp')->get();
+
+        $this->assertCount(1, $results);
+        $this->assertSame('Alpha', $results->first()->name);
+    }
+
+    public function test_search_scope_uses_custom_column(): void
+    {
+        SearchScopeCustomModel::create(['name' => 'X', 'label' => 'Special']);
+        SearchScopeCustomModel::create(['name' => 'Y', 'label' => 'Other']);
+
+        $results = SearchScopeCustomModel::search('spe')->get();
+
+        $this->assertCount(1, $results);
+        $this->assertSame('Special', $results->first()->label);
+    }
+}
+
+class SearchScopeDefaultModel extends Model
+{
+    use HasSearchScope;
+
+    protected $table = 'search_scope_defaults';
+
+    protected $fillable = ['name'];
+
+    public $timestamps = false;
+}
+
+class SearchScopeCustomModel extends Model
+{
+    use HasSearchScope;
+
+    protected $table = 'search_scope_customs';
+
+    protected $fillable = ['name', 'label'];
+
+    protected string $searchColumn = 'label';
+
+    public $timestamps = false;
+}


### PR DESCRIPTION
## Summary
- use generic HasSearchScope on Room and Table models
- allow configurable search column with SQLite fallback
- adjust tests for case-insensitive search
- add unit coverage for HasSearchScope

## Testing
- `./vendor/bin/pint`
- `./vendor/bin/phpstan analyse --memory-limit=2G`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c815586b34832d8a9670fa607e206d