### PR TITLE
Restrict menu service types to PREP or DIRECT

### DIFF
--- a/app/Enums/MenuServiceType.php
+++ b/app/Enums/MenuServiceType.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Enums;
+
+enum MenuServiceType: string
+{
+    case PREP = 'PREP';
+    case DIRECT = 'DIRECT';
+
+    /**
+     * @return array<int, string>
+     */
+    public static function values(): array
+    {
+        return array_map(static fn (self $case) => $case->value, self::cases());
+    }
+}

--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Enums\MeasurementUnit;
+use App\Enums\MenuServiceType;
 use App\Models\Ingredient;
 use App\Models\Menu;
 use App\Models\MenuItem;
@@ -35,6 +36,8 @@ class MenuController extends Controller
                 Rule::unique('menus')->where(fn ($q) => $q->where('company_id', $user->company_id)),
             ],
             'type' => ['required', 'string', 'max:255'],
+            'service_type' => ['required', 'string', Rule::in(MenuServiceType::values())],
+            'is_returnable' => ['required', 'boolean'],
             'price' => ['required', 'numeric', 'min:0'],
             'category_ids' => ['sometimes', 'array'],
             'category_ids.*' => [
@@ -89,6 +92,8 @@ class MenuController extends Controller
             'is_a_la_carte' => $validated['is_a_la_carte'] ?? false,
             'image_url' => $imagePath,
             'type' => $validated['type'],
+            'service_type' => $validated['service_type'],
+            'is_returnable' => $validated['is_returnable'],
             'price' => $validated['price'],
         ]);
 
@@ -141,6 +146,8 @@ class MenuController extends Controller
                 Rule::unique('menus')->where(fn ($q) => $q->where('company_id', $user->company_id))->ignore($menu->id),
             ],
             'type' => ['sometimes', 'string', 'max:255'],
+            'service_type' => ['sometimes', 'string', Rule::in(MenuServiceType::values())],
+            'is_returnable' => ['sometimes', 'boolean'],
             'price' => ['sometimes', 'numeric', 'min:0'],
             'category_ids' => ['sometimes', 'array'],
             'category_ids.*' => [
@@ -198,6 +205,12 @@ class MenuController extends Controller
         }
         if (array_key_exists('type', $validated)) {
             $menu->type = $validated['type'];
+        }
+        if (array_key_exists('service_type', $validated)) {
+            $menu->service_type = $validated['service_type'];
+        }
+        if (array_key_exists('is_returnable', $validated)) {
+            $menu->is_returnable = $validated['is_returnable'];
         }
         if (array_key_exists('price', $validated)) {
             $menu->price = $validated['price'];

--- a/app/Models/Menu.php
+++ b/app/Models/Menu.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\MenuServiceType;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -22,12 +23,16 @@ class Menu extends Model
         'description',
         'image_url',
         'is_a_la_carte',
+        'service_type',
+        'is_returnable',
         'type',
         'price',
     ];
 
     protected $casts = [
         'is_a_la_carte' => 'boolean',
+        'service_type' => MenuServiceType::class,
+        'is_returnable' => 'boolean',
         'price' => 'float',
     ];
 
@@ -108,6 +113,22 @@ class Menu extends Model
         $types = is_array($types) ? $types : [$types];
 
         return $query->whereIn('type', $types);
+    }
+
+    public function scopeServiceType($query, $serviceTypes)
+    {
+        if (empty($serviceTypes)) {
+            return $query;
+        }
+
+        $serviceTypes = is_array($serviceTypes) ? $serviceTypes : [$serviceTypes];
+
+        $serviceTypes = array_map(
+            fn ($serviceType) => $serviceType instanceof MenuServiceType ? $serviceType->value : $serviceType,
+            $serviceTypes
+        );
+
+        return $query->whereIn('service_type', $serviceTypes);
     }
 
     public function scopePriceBetween($query, $prices)

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Enums\Allergen;
 use App\Enums\MeasurementUnit;
+use App\Enums\MenuServiceType;
 use App\Services\OpenFoodFactsService;
 use GraphQL\Type\Definition\EnumType;
 use Illuminate\Support\ServiceProvider;
@@ -42,6 +43,14 @@ class AppServiceProvider extends ServiceProvider
             'values' => collect(Allergen::cases())
                 ->mapWithKeys(fn ($c) => [
                     $c->value => ['value' => $c->value],
+                ])->all(),
+        ]));
+
+        $typeRegistry->register(new EnumType([
+            'name' => 'MenuServiceTypeEnum',
+            'values' => collect(MenuServiceType::cases())
+                ->mapWithKeys(fn ($c) => [
+                    $c->value => ['value' => $c],
                 ])->all(),
         ]));
     }

--- a/database/factories/MenuFactory.php
+++ b/database/factories/MenuFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\MenuServiceType;
 use App\Models\Company;
 use App\Models\Menu;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -18,6 +19,8 @@ class MenuFactory extends Factory
             'description' => $this->faker->sentence(),
             'image_url' => null,
             'is_a_la_carte' => $this->faker->boolean(),
+            'service_type' => $this->faker->randomElement(MenuServiceType::values()),
+            'is_returnable' => $this->faker->boolean(),
             'type' => $this->faker->randomElement(['entrée', 'plat', 'dessert', 'side']),
             'price' => $this->faker->randomFloat(2, 5, 50),
         ];

--- a/database/migrations/2025_09_20_000000_add_service_type_and_is_returnable_to_menus_table.php
+++ b/database/migrations/2025_09_20_000000_add_service_type_and_is_returnable_to_menus_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('menus', function (Blueprint $table) {
+            $table->string('service_type')->default('DIRECT')->after('type');
+            $table->boolean('is_returnable')->default(false)->after('service_type');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('menus', function (Blueprint $table) {
+            $table->dropColumn(['service_type', 'is_returnable']);
+        });
+    }
+};

--- a/database/seeders/MenuSeeder.php
+++ b/database/seeders/MenuSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Enums\MeasurementUnit;
+use App\Enums\MenuServiceType;
 use App\Models\Company;
 use App\Models\Ingredient;
 use App\Models\Location;
@@ -27,6 +28,8 @@ class MenuSeeder extends Seeder
             for ($i = 0; $i < 5; $i++) {
                 $menu = Menu::factory()->create([
                     'company_id' => $company->id,
+                    'service_type' => fake()->randomElement(MenuServiceType::values()),
+                    'is_returnable' => fake()->boolean(),
                     'type' => fake()->randomElement(['entrée', 'plat', 'dessert', 'side']),
                     'price' => fake()->randomFloat(2, 5, 50),
                 ]);

--- a/graphql/models/menu.graphql
+++ b/graphql/models/menu.graphql
@@ -4,6 +4,8 @@ type Menu {
     description: String
     image_url: String @field(resolver: "App\\GraphQL\\Resolvers\\MenuResolver@imageUrl")
     is_a_la_carte: Boolean!
+    service_type: MenuServiceTypeEnum!
+    is_returnable: Boolean!
     available(quantity: Int! = 1): Boolean! @field(resolver: "App\\GraphQL\\Resolvers\\MenuResolver@available")
     type: String!
     price: Float!
@@ -32,6 +34,8 @@ extend type Query @guard {
         category_ids: [ID!] @scope(name: "category")
         "Filtrer par un ou plusieurs types."
         types: [String!] @scope(name: "type")
+        "Filtrer par type de service (PREP, DIRECT)."
+        service_types: [MenuServiceTypeEnum!] @scope(name: "serviceType")
         "Filtrer par un range de prix [min, max]."
         price_between: [Float!] @scope(name: "priceBetween")
         "Filtrer par disponibilité."

--- a/tests/Feature/MenuControllerTest.php
+++ b/tests/Feature/MenuControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Enums\MenuServiceType;
 use App\Models\Company;
 use App\Models\Ingredient;
 use App\Models\Location;
@@ -37,6 +38,8 @@ class MenuControllerTest extends TestCase
             ->postJson('/api/menus', [
                 'name' => 'Incremental Menu',
                 'type' => 'plat',
+                'service_type' => MenuServiceType::DIRECT->value,
+                'is_returnable' => false,
                 'price' => 9.0,
                 'category_ids' => [],
                 'items' => [
@@ -52,6 +55,8 @@ class MenuControllerTest extends TestCase
             ->assertStatus(201);
 
         $menu = Menu::where('name', 'Incremental Menu')->first();
+        $this->assertSame(MenuServiceType::DIRECT, $menu->service_type);
+        $this->assertFalse($menu->is_returnable);
 
         // Remplacement par deux ingrédients
         $this->actingAs($user)
@@ -106,6 +111,8 @@ class MenuControllerTest extends TestCase
             ->postJson('/api/menus', [
                 'name' => 'Quantity Menu',
                 'type' => 'plat',
+                'service_type' => MenuServiceType::PREP->value,
+                'is_returnable' => true,
                 'price' => 9.0,
                 'category_ids' => [],
                 'items' => [
@@ -121,6 +128,8 @@ class MenuControllerTest extends TestCase
             ->assertStatus(201);
 
         $menu = Menu::where('name', 'Quantity Menu')->first();
+        $this->assertSame(MenuServiceType::PREP, $menu->service_type);
+        $this->assertTrue($menu->is_returnable);
 
         $this->actingAs($user)
             ->putJson('/api/menus/'.$menu->id, [
@@ -153,6 +162,8 @@ class MenuControllerTest extends TestCase
             ->postJson('/api/menus', [
                 'name' => 'Cat Menu',
                 'type' => 'plat',
+                'service_type' => MenuServiceType::DIRECT->value,
+                'is_returnable' => false,
                 'price' => 9.0,
                 'category_ids' => [$categoryA->id],
                 'items' => [
@@ -199,6 +210,8 @@ class MenuControllerTest extends TestCase
         $payload = [
             'name' => 'Dup Menu',
             'type' => 'plat',
+            'service_type' => MenuServiceType::DIRECT->value,
+            'is_returnable' => false,
             'price' => 9.0,
             'category_ids' => [],
             'items' => [


### PR DESCRIPTION
## Summary
- add a migration that introduces `service_type` and `is_returnable` columns on menus with a default of `DIRECT`
- update the Menu model, controller validation, and creation/update flows to treat service type as a strict enum (`PREP`/`DIRECT`)
- refresh the menu factory and controller tests to cover the new service configuration fields and enum values
- add a `MenuServiceType` enum to centralize allowed service types
- expose the menu service type enum and returnable flag through the GraphQL schema and seed data

## Testing
- ./vendor/bin/pint
- ./vendor/bin/phpstan analyse --memory-limit=1G
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68c890010538832d94f11abbb3c4e8f8