### PR TITLE
Step and StepMenu for orders

### DIFF
--- a/app/Enums/OrderStepStatus.php
+++ b/app/Enums/OrderStepStatus.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Enums;
+
+enum OrderStepStatus: string
+{
+    case PENDING = 'PENDING';
+    case IN_PREP = 'IN_PREP';
+    case READY = 'READY';
+    case SERVED = 'SERVED';
+
+    public static function values(): array
+    {
+        return array_map(static fn (self $case) => $case->value, self::cases());
+    }
+}

--- a/app/Enums/StepMenuStatus.php
+++ b/app/Enums/StepMenuStatus.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Enums;
+
+enum StepMenuStatus: string
+{
+    case PENDING = 'PENDING';
+    case IN_PREP = 'IN_PREP';
+    case READY = 'READY';
+    case SERVED = 'SERVED';
+
+    public static function values(): array
+    {
+        return array_map(static fn (self $case) => $case->value, self::cases());
+    }
+}

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -6,6 +6,8 @@ use App\Enums\OrderStatus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
 class Order extends Model
 {
@@ -49,5 +51,22 @@ class Order extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function steps(): HasMany
+    {
+        return $this->hasMany(OrderStep::class);
+    }
+
+    public function menus(): HasManyThrough
+    {
+        return $this->hasManyThrough(
+            StepMenu::class,
+            OrderStep::class,
+            'order_id',
+            'order_step_id',
+            'id',
+            'id'
+        )->with('menu');
     }
 }

--- a/app/Models/OrderStep.php
+++ b/app/Models/OrderStep.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\OrderStepStatus;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class OrderStep extends Model
+{
+    /** @use HasFactory<\Database\Factories\OrderStepFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'order_id',
+        'name',
+        'position',
+        'status',
+        'served_at',
+    ];
+
+    protected $casts = [
+        'position' => 'integer',
+        'status' => OrderStepStatus::class,
+        'served_at' => 'datetime',
+    ];
+
+    public function order(): BelongsTo
+    {
+        return $this->belongsTo(Order::class);
+    }
+
+    public function stepMenus(): HasMany
+    {
+        return $this->hasMany(StepMenu::class);
+    }
+
+    public function menus(): BelongsToMany
+    {
+        return $this->belongsToMany(Menu::class, 'step_menus', 'order_step_id', 'menu_id')
+            ->withPivot('quantity', 'status', 'note', 'served_at')
+            ->withTimestamps();
+    }
+}

--- a/app/Models/StepMenu.php
+++ b/app/Models/StepMenu.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\StepMenuStatus;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class StepMenu extends Model
+{
+    /** @use HasFactory<\Database\Factories\StepMenuFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'order_step_id',
+        'menu_id',
+        'quantity',
+        'status',
+        'note',
+        'served_at',
+    ];
+
+    protected $casts = [
+        'quantity' => 'integer',
+        'status' => StepMenuStatus::class,
+        'served_at' => 'datetime',
+    ];
+
+    public function step(): BelongsTo
+    {
+        return $this->belongsTo(OrderStep::class, 'order_step_id');
+    }
+
+    public function menu(): BelongsTo
+    {
+        return $this->belongsTo(Menu::class);
+    }
+}

--- a/database/factories/OrderStepFactory.php
+++ b/database/factories/OrderStepFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\OrderStepStatus;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\OrderStep>
+ */
+class OrderStepFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->sentence(2),
+            'position' => $this->faker->numberBetween(1, 5),
+            'status' => $this->faker->randomElement(OrderStepStatus::values()),
+            'served_at' => $this->faker->optional()->dateTime(),
+        ];
+    }
+}

--- a/database/factories/StepMenuFactory.php
+++ b/database/factories/StepMenuFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\StepMenuStatus;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\StepMenu>
+ */
+class StepMenuFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'quantity' => $this->faker->numberBetween(1, 10),
+            'status' => $this->faker->randomElement(StepMenuStatus::values()),
+            'note' => $this->faker->optional()->sentence(),
+            'served_at' => $this->faker->optional()->dateTime(),
+        ];
+    }
+}

--- a/database/migrations/2025_09_16_162959_create_orders_table.php
+++ b/database/migrations/2025_09_16_162959_create_orders_table.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Enums\OrderStatus;
+use App\Enums\OrderStepStatus;
+use App\Enums\StepMenuStatus;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -30,6 +32,33 @@ return new class extends Migration
 
             $table->timestamps();
         });
+
+        Schema::create('order_steps', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('order_id')->constrained()->cascadeOnDelete();
+
+            $table->string('name');
+            $table->unsignedInteger('position')->default(0);
+            $table->enum('status', OrderStepStatus::values());
+            $table->timestamp('served_at')->nullable();
+
+            $table->timestamps();
+        });
+
+        Schema::create('step_menus', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('order_step_id')->constrained('order_steps')->cascadeOnDelete();
+            $table->foreignId('menu_id')->constrained()->cascadeOnDelete();
+
+            $table->unsignedInteger('quantity')->default(1);
+            $table->enum('status', StepMenuStatus::values());
+            $table->text('note')->nullable();
+            $table->timestamp('served_at')->nullable();
+
+            $table->timestamps();
+        });
     }
 
     /**
@@ -37,6 +66,8 @@ return new class extends Migration
      */
     public function down(): void
     {
+        Schema::dropIfExists('step_menus');
+        Schema::dropIfExists('order_steps');
         Schema::dropIfExists('orders');
     }
 };

--- a/database/seeders/OrderStepSeeder.php
+++ b/database/seeders/OrderStepSeeder.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+class OrderStepSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        //
+    }
+}

--- a/database/seeders/StepMenuSeeder.php
+++ b/database/seeders/StepMenuSeeder.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+class StepMenuSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        //
+    }
+}


### PR DESCRIPTION
## Summary
- add served_at tracking to order steps and step menus while dropping status defaults
- expose an Order::menus() shortcut that surfaces related step menus with their menus eager loaded
- update the order step and step menu factories to include optional served_at timestamps for testing data

## Testing
- ./vendor/bin/pint
- ./vendor/bin/phpstan analyse --memory-limit=512M

------
https://chatgpt.com/codex/tasks/task_e_68c97e2122b4832db7241f62c62a35d7