### PR TITLE
Add computed price accessors for orders and steps

### DIFF
--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -9,6 +9,9 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
+/**
+ * @property-read float $price
+ */
 class Order extends Model
 {
     /** @use HasFactory<\Database\Factories\OrderFactory> */
@@ -35,6 +38,10 @@ class Order extends Model
         'served_at' => 'datetime',
         'payed_at' => 'datetime',
         'canceled_at' => 'datetime',
+    ];
+
+    protected $appends = [
+        'price',
     ];
 
     // Relations (adapter les classes si vos modèles diffèrent)
@@ -68,5 +75,19 @@ class Order extends Model
             'id',
             'id'
         )->with('menu');
+    }
+
+    public function getPriceAttribute(): float
+    {
+        $this->loadMissing('steps.stepMenus.menu');
+
+        $total = 0.0;
+
+        foreach ($this->steps as $step) {
+            /** @var OrderStep $step */
+            $total += (float) $step->price;
+        }
+
+        return $total;
     }
 }

--- a/app/Models/StepMenu.php
+++ b/app/Models/StepMenu.php
@@ -7,6 +7,10 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * @property Menu|null $menu
+ * @property int $quantity
+ */
 class StepMenu extends Model
 {
     /** @use HasFactory<\Database\Factories\StepMenuFactory> */


### PR DESCRIPTION
## Summary
- add a computed price accessor on order steps that totals related menu prices and quantities
- expose an order price accessor that aggregates the prices of its steps
- document StepMenu relations to satisfy static analysis

## Testing
- ./vendor/bin/pint
- ./vendor/bin/phpstan analyse --memory-limit=1G

------
https://chatgpt.com/codex/tasks/task_e_68c99e518dc4832d9a813c5510f82cd6