### PR TITLE
Add GraphQL support for orders and cover new queries with tests

### DIFF
--- a/app/GraphQL/Resolvers/OrdersResolver.php
+++ b/app/GraphQL/Resolvers/OrdersResolver.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\GraphQL\Resolvers;
+
+use App\Enums\OrderStatus;
+use App\Models\Order;
+use Carbon\Carbon;
+
+class OrdersResolver
+{
+    /**
+     * @param  array<string, mixed>  $args
+     * @return array<string, float|int>
+     */
+    public function stats(null $_, array $args): array
+    {
+        $start = isset($args['start_date']) ? Carbon::parse($args['start_date']) : null;
+        $end = isset($args['end_date']) ? Carbon::parse($args['end_date']) : null;
+
+        $query = Order::query()->forCompany();
+
+        if (isset($args['table_id'])) {
+            $query->where('table_id', $args['table_id']);
+        }
+
+        if (isset($args['user_id'])) {
+            $query->where('user_id', $args['user_id']);
+        }
+
+        if (isset($args['statuses']) && $args['statuses'] !== []) {
+            $query->status($args['statuses']);
+        }
+
+        if ($start && $end) {
+            $query->whereBetween('created_at', [$start, $end]);
+        } elseif ($start) {
+            $query->where('created_at', '>=', $start);
+        } elseif ($end) {
+            $query->where('created_at', '<=', $end);
+        }
+
+        $baseQuery = clone $query;
+
+        $counts = [];
+        foreach (OrderStatus::cases() as $status) {
+            $counts[$status->value] = (clone $baseQuery)
+                ->where('status', $status->value)
+                ->count();
+        }
+
+        $revenue = (clone $baseQuery)
+            ->where('status', OrderStatus::PAYED->value)
+            ->with('steps.stepMenus.menu')
+            ->get()
+            ->sum(static fn (Order $order): float => $order->price);
+
+        return [
+            'pending' => (int) ($counts[OrderStatus::PENDING->value] ?? 0),
+            'in_prep' => (int) ($counts[OrderStatus::IN_PREP->value] ?? 0),
+            'ready' => (int) ($counts[OrderStatus::READY->value] ?? 0),
+            'served' => (int) ($counts[OrderStatus::SERVED->value] ?? 0),
+            'payed' => (int) ($counts[OrderStatus::PAYED->value] ?? 0),
+            'cancelled' => (int) ($counts[OrderStatus::CANCELLED->value] ?? 0),
+            'total' => (int) array_sum($counts),
+            'revenue' => (float) $revenue,
+        ];
+    }
+}

--- a/app/Models/OrderStep.php
+++ b/app/Models/OrderStep.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\OrderStepStatus;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -70,5 +71,29 @@ class OrderStep extends Model
         }
 
         return $total;
+    }
+
+    public function scopeForCompany(Builder $query): Builder
+    {
+        return $query->whereHas('order', static function (Builder $order): void {
+            $order->where('company_id', auth()->user()->company_id);
+        });
+    }
+
+    /**
+     * @param  array<int, OrderStepStatus|string>  $statuses
+     */
+    public function scopeStatus(Builder $query, array $statuses): Builder
+    {
+        if ($statuses === []) {
+            return $query;
+        }
+
+        $values = array_map(
+            fn (OrderStepStatus|string $status): string => $status instanceof OrderStepStatus ? $status->value : (string) $status,
+            $statuses,
+        );
+
+        return $query->whereIn('status', $values);
     }
 }

--- a/app/Models/StepMenu.php
+++ b/app/Models/StepMenu.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\StepMenuStatus;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -39,5 +40,29 @@ class StepMenu extends Model
     public function menu(): BelongsTo
     {
         return $this->belongsTo(Menu::class);
+    }
+
+    public function scopeForCompany(Builder $query): Builder
+    {
+        return $query->whereHas('step.order', static function (Builder $order): void {
+            $order->where('company_id', auth()->user()->company_id);
+        });
+    }
+
+    /**
+     * @param  array<int, StepMenuStatus|string>  $statuses
+     */
+    public function scopeStatus(Builder $query, array $statuses): Builder
+    {
+        if ($statuses === []) {
+            return $query;
+        }
+
+        $values = array_map(
+            fn (StepMenuStatus|string $status): string => $status instanceof StepMenuStatus ? $status->value : (string) $status,
+            $statuses,
+        );
+
+        return $query->whereIn('status', $values);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,9 @@ namespace App\Providers;
 use App\Enums\Allergen;
 use App\Enums\MeasurementUnit;
 use App\Enums\MenuServiceType;
+use App\Enums\OrderStatus;
+use App\Enums\OrderStepStatus;
+use App\Enums\StepMenuStatus;
 use App\Services\OpenFoodFactsService;
 use GraphQL\Type\Definition\EnumType;
 use Illuminate\Support\ServiceProvider;
@@ -49,6 +52,30 @@ class AppServiceProvider extends ServiceProvider
         $typeRegistry->register(new EnumType([
             'name' => 'MenuServiceTypeEnum',
             'values' => collect(MenuServiceType::cases())
+                ->mapWithKeys(fn ($c) => [
+                    $c->value => ['value' => $c],
+                ])->all(),
+        ]));
+
+        $typeRegistry->register(new EnumType([
+            'name' => 'OrderStatusEnum',
+            'values' => collect(OrderStatus::cases())
+                ->mapWithKeys(fn ($c) => [
+                    $c->value => ['value' => $c],
+                ])->all(),
+        ]));
+
+        $typeRegistry->register(new EnumType([
+            'name' => 'OrderStepStatusEnum',
+            'values' => collect(OrderStepStatus::cases())
+                ->mapWithKeys(fn ($c) => [
+                    $c->value => ['value' => $c],
+                ])->all(),
+        ]));
+
+        $typeRegistry->register(new EnumType([
+            'name' => 'StepMenuStatusEnum',
+            'values' => collect(StepMenuStatus::cases())
                 ->mapWithKeys(fn ($c) => [
                     $c->value => ['value' => $c],
                 ])->all(),

--- a/graphql/models/order.graphql
+++ b/graphql/models/order.graphql
@@ -1,0 +1,128 @@
+"""
+Représente une commande passée dans l'établissement.
+"""
+type Order {
+    "Identifiant unique."
+    id: ID!
+
+    "Table associée à la commande."
+    table: Table! @belongsTo
+
+    "Entreprise propriétaire de la commande."
+    company: Company! @belongsTo
+
+    "Utilisateur qui a créé la commande."
+    user: User! @belongsTo
+
+    "Statut actuel de la commande."
+    status: OrderStatusEnum!
+
+    "Horodatage du passage de la commande en statut PENDING."
+    pending_at: DateTime
+
+    "Horodatage du passage de la commande en préparation."
+    in_prep_at: DateTime
+
+    "Horodatage indiquant que la commande est prête."
+    ready_at: DateTime
+
+    "Horodatage du service de la commande."
+    served_at: DateTime
+
+    "Horodatage du paiement de la commande."
+    payed_at: DateTime
+
+    "Horodatage de l'annulation éventuelle."
+    canceled_at: DateTime
+
+    "Prix total calculé de la commande."
+    price: Float!
+
+    "Étapes associées à la commande."
+    steps: [OrderStep!]! @hasMany
+
+    "Date de création de la commande."
+    created_at: DateTime!
+
+    "Date de dernière mise à jour."
+    updated_at: DateTime!
+}
+
+"""
+Statistiques agrégées sur les commandes.
+"""
+type OrdersStats {
+    pending: Int!
+    in_prep: Int!
+    ready: Int!
+    served: Int!
+    payed: Int!
+    cancelled: Int!
+    total: Int!
+    revenue: Float!
+}
+
+extend type Query @guard {
+    "Liste les commandes pour l'entreprise courante."
+    orders(
+        "Filtre par statut (plusieurs valeurs possibles)."
+        statuses: [OrderStatusEnum!] @scope(name: "status")
+
+        "Filtre par identifiant de table."
+        table_id: ID @where(key: "table_id")
+
+        "Filtre par identifiant d'utilisateur."
+        user_id: ID @where(key: "user_id")
+
+        "Filtre par date de création minimale."
+        start_date: DateTime @scope(name: "createdAfter")
+
+        "Filtre par date de création maximale."
+        end_date: DateTime @scope(name: "createdBefore")
+
+        "Options de tri des commandes."
+        orderBy: [OrderOrderByClause!] @orderBy(columnsEnum: OrderOrderByField)
+    ): [Order!]! @paginate(defaultCount: 10, scopes: ["forCompany"])
+
+    "Récupère une commande précise (si elle appartient à l'entreprise courante)."
+    order(id: ID! @eq): Order @find(scopes: ["forCompany"])
+
+    "Retourne les statistiques des commandes sur une période."
+    ordersStats(
+        statuses: [OrderStatusEnum!]
+        table_id: ID
+        user_id: ID
+        start_date: DateTime
+        end_date: DateTime
+    ): OrdersStats!
+        @field(resolver: "App\\GraphQL\\Resolvers\\OrdersResolver@stats")
+}
+
+"""
+Options de tri disponibles pour les commandes.
+"""
+input OrderOrderByClause {
+    "Colonne utilisée pour le tri."
+    column: OrderOrderByField!
+
+    "Direction du tri."
+    order: SortOrder! = ASC
+}
+
+"""
+Colonnes triables pour les commandes.
+"""
+enum OrderOrderByField {
+    ID @enum(value: "id")
+    STATUS @enum(value: "status")
+    TABLE_ID @enum(value: "table_id")
+    USER_ID @enum(value: "user_id")
+    PENDING_AT @enum(value: "pending_at")
+    IN_PREP_AT @enum(value: "in_prep_at")
+    READY_AT @enum(value: "ready_at")
+    SERVED_AT @enum(value: "served_at")
+    PAYED_AT @enum(value: "payed_at")
+    CANCELED_AT @enum(value: "canceled_at")
+    CREATED_AT @enum(value: "created_at")
+    UPDATED_AT @enum(value: "updated_at")
+}

--- a/graphql/models/orderStep.graphql
+++ b/graphql/models/orderStep.graphql
@@ -1,0 +1,79 @@
+"""
+Étape individuelle d'une commande.
+"""
+type OrderStep {
+    "Identifiant unique."
+    id: ID!
+
+    "Commande à laquelle appartient l'étape."
+    order: Order! @belongsTo
+
+    "Nom de l'étape (ex: Entrées, Plats, etc.)."
+    name: String!
+
+    "Position de l'étape dans le flux de service."
+    position: Int!
+
+    "Statut actuel de l'étape."
+    status: OrderStepStatusEnum!
+
+    "Horodatage du service de l'étape."
+    served_at: DateTime
+
+    "Prix agrégé des menus associés."
+    price: Float!
+
+    "Menus associés à cette étape."
+    stepMenus: [StepMenu!]! @hasMany
+
+    "Menus liés via la relation pivot."
+    menus: [Menu!]! @belongsToMany
+
+    "Date de création de l'étape."
+    created_at: DateTime!
+
+    "Date de dernière mise à jour."
+    updated_at: DateTime!
+}
+
+extend type Query @guard {
+    "Liste les étapes de commandes."
+    orderSteps(
+        "Filtre par identifiant de commande."
+        order_id: ID @where(key: "order_id")
+
+        "Filtre par statut."
+        statuses: [OrderStepStatusEnum!] @scope(name: "status")
+
+        "Options de tri des étapes."
+        orderBy: [OrderStepOrderByClause!] @orderBy(columnsEnum: OrderStepOrderByField)
+    ): [OrderStep!]! @paginate(defaultCount: 10, scopes: ["forCompany"])
+
+    "Récupère une étape précise."
+    orderStep(id: ID! @eq): OrderStep @find(scopes: ["forCompany"])
+}
+
+"""
+Options de tri disponibles pour les étapes de commande.
+"""
+input OrderStepOrderByClause {
+    "Colonne utilisée pour le tri."
+    column: OrderStepOrderByField!
+
+    "Direction du tri."
+    order: SortOrder! = ASC
+}
+
+"""
+Colonnes triables pour les étapes de commande.
+"""
+enum OrderStepOrderByField {
+    ID @enum(value: "id")
+    ORDER_ID @enum(value: "order_id")
+    NAME @enum(value: "name")
+    POSITION @enum(value: "position")
+    STATUS @enum(value: "status")
+    SERVED_AT @enum(value: "served_at")
+    CREATED_AT @enum(value: "created_at")
+    UPDATED_AT @enum(value: "updated_at")
+}

--- a/graphql/models/stepMenu.graphql
+++ b/graphql/models/stepMenu.graphql
@@ -1,0 +1,76 @@
+"""
+Association entre une étape de commande et un menu.
+"""
+type StepMenu {
+    "Identifiant unique."
+    id: ID!
+
+    "Étape de commande liée."
+    step: OrderStep! @belongsTo(relation: "step")
+
+    "Menu associé à cette ligne."
+    menu: Menu! @belongsTo
+
+    "Quantité commandée."
+    quantity: Int!
+
+    "Statut de la ligne de menu."
+    status: StepMenuStatusEnum!
+
+    "Note éventuelle ajoutée par l'équipe."
+    note: String
+
+    "Horodatage du service de ce menu."
+    served_at: DateTime
+
+    "Date de création de la ligne."
+    created_at: DateTime!
+
+    "Date de dernière mise à jour."
+    updated_at: DateTime!
+}
+
+extend type Query @guard {
+    "Liste les menus associés aux étapes de commandes."
+    stepMenus(
+        "Filtre par identifiant d'étape de commande."
+        order_step_id: ID @where(key: "order_step_id")
+
+        "Filtre par identifiant de menu."
+        menu_id: ID @where(key: "menu_id")
+
+        "Filtre par statut."
+        statuses: [StepMenuStatusEnum!] @scope(name: "status")
+
+        "Options de tri des lignes."
+        orderBy: [StepMenuOrderByClause!] @orderBy(columnsEnum: StepMenuOrderByField)
+    ): [StepMenu!]! @paginate(defaultCount: 10, scopes: ["forCompany"])
+
+    "Récupère une ligne précise."
+    stepMenu(id: ID! @eq): StepMenu @find(scopes: ["forCompany"])
+}
+
+"""
+Options de tri disponibles pour les menus d'une étape.
+"""
+input StepMenuOrderByClause {
+    "Colonne utilisée pour le tri."
+    column: StepMenuOrderByField!
+
+    "Direction du tri."
+    order: SortOrder! = ASC
+}
+
+"""
+Colonnes triables pour les menus d'une étape.
+"""
+enum StepMenuOrderByField {
+    ID @enum(value: "id")
+    ORDER_STEP_ID @enum(value: "order_step_id")
+    MENU_ID @enum(value: "menu_id")
+    QUANTITY @enum(value: "quantity")
+    STATUS @enum(value: "status")
+    SERVED_AT @enum(value: "served_at")
+    CREATED_AT @enum(value: "created_at")
+    UPDATED_AT @enum(value: "updated_at")
+}

--- a/tests/Feature/OrderQueryTest.php
+++ b/tests/Feature/OrderQueryTest.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\OrderStatus;
+use App\Enums\OrderStepStatus;
+use App\Enums\StepMenuStatus;
+use App\Models\Menu;
+use App\Models\Order;
+use App\Models\OrderStep;
+use App\Models\Room;
+use App\Models\StepMenu;
+use App\Models\Table;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Tests\TestCase;
+
+class OrderQueryTest extends TestCase
+{
+    use MakesGraphQLRequests;
+    use RefreshDatabase;
+
+    private function createTableForUser(User $user): Table
+    {
+        $room = Room::factory()->for($user->company)->create();
+
+        return Table::factory()
+            ->for($room, 'room')
+            ->for($user->company)
+            ->create();
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    private function createOrderForUser(User $user, array $attributes = []): Order
+    {
+        $attributes = array_merge([
+            'table_id' => $this->createTableForUser($user)->id,
+            'company_id' => $user->company_id,
+            'user_id' => $user->id,
+            'status' => OrderStatus::PENDING,
+        ], $attributes);
+
+        return Order::create($attributes);
+    }
+
+    public function test_it_lists_orders_for_company(): void
+    {
+        $user = User::factory()->create();
+        $order = $this->createOrderForUser($user);
+
+        $otherUser = User::factory()->create();
+        $otherOrder = $this->createOrderForUser($otherUser);
+
+        $response = $this->actingAs($user)->graphQL(/** @lang GraphQL */ '{
+            orders {
+                data { id }
+            }
+        }');
+
+        $response->assertJsonCount(1, 'data.orders.data');
+        $response->assertJsonFragment(['id' => (string) $order->id]);
+        $response->assertJsonMissing(['id' => (string) $otherOrder->id]);
+    }
+
+    public function test_it_filters_orders_by_status(): void
+    {
+        $user = User::factory()->create();
+        $pending = $this->createOrderForUser($user, ['status' => OrderStatus::PENDING]);
+        $ready = $this->createOrderForUser($user, ['status' => OrderStatus::READY]);
+
+        $query = /** @lang GraphQL */ 'query ($statuses: [OrderStatusEnum!]) {
+            orders(statuses: $statuses) {
+                data { id status }
+            }
+        }';
+
+        $response = $this->actingAs($user)->graphQL($query, [
+            'statuses' => [OrderStatus::PENDING->value],
+        ]);
+
+        $response->assertJsonCount(1, 'data.orders.data');
+        $response->assertJsonFragment([
+            'id' => (string) $pending->id,
+            'status' => OrderStatus::PENDING->value,
+        ]);
+        $response->assertJsonMissing(['id' => (string) $ready->id]);
+    }
+
+    public function test_it_filters_orders_by_start_date(): void
+    {
+        $user = User::factory()->create();
+        $older = $this->createOrderForUser($user);
+        $older->forceFill(['created_at' => now()->subDays(3)])->save();
+
+        $newer = $this->createOrderForUser($user);
+
+        $query = /** @lang GraphQL */ 'query ($start: DateTime) {
+            orders(start_date: $start) {
+                data { id }
+            }
+        }';
+
+        $response = $this->actingAs($user)->graphQL($query, [
+            'start' => now()->subDay()->format('Y-m-d H:i:s'),
+        ]);
+
+        $response->assertJsonCount(1, 'data.orders.data');
+        $response->assertJsonFragment(['id' => (string) $newer->id]);
+        $response->assertJsonMissing(['id' => (string) $older->id]);
+    }
+
+    public function test_it_orders_orders_by_created_at_desc(): void
+    {
+        $user = User::factory()->create();
+        $older = $this->createOrderForUser($user);
+        $older->forceFill(['created_at' => now()->subDay()])->save();
+
+        $newer = $this->createOrderForUser($user);
+
+        $response = $this->actingAs($user)->graphQL(/** @lang GraphQL */ '{
+            orders(orderBy: [{column: CREATED_AT, order: DESC}]) {
+                data { id }
+            }
+        }');
+
+        $response->assertJsonPath('data.orders.data.0.id', (string) $newer->id);
+        $response->assertJsonPath('data.orders.data.1.id', (string) $older->id);
+    }
+
+    public function test_it_fetches_order_by_id(): void
+    {
+        $user = User::factory()->create();
+        $order = $this->createOrderForUser($user);
+
+        $query = /** @lang GraphQL */ 'query ($id: ID!) {
+            order(id: $id) { id status }
+        }';
+
+        $response = $this->actingAs($user)->graphQL($query, ['id' => $order->id]);
+
+        $response->assertJsonPath('data.order.id', (string) $order->id);
+        $response->assertJsonPath('data.order.status', OrderStatus::PENDING->value);
+    }
+
+    public function test_it_returns_orders_stats(): void
+    {
+        $user = User::factory()->create();
+
+        $payedOrder = $this->createOrderForUser($user, ['status' => OrderStatus::PAYED]);
+        $step = OrderStep::create([
+            'order_id' => $payedOrder->id,
+            'name' => 'Service',
+            'position' => 1,
+            'status' => OrderStepStatus::SERVED,
+        ]);
+
+        $menuA = Menu::factory()->for($user->company)->create(['price' => 12.5]);
+        $menuB = Menu::factory()->for($user->company)->create(['price' => 5.25]);
+
+        StepMenu::create([
+            'order_step_id' => $step->id,
+            'menu_id' => $menuA->id,
+            'quantity' => 2,
+            'status' => StepMenuStatus::SERVED,
+        ]);
+
+        StepMenu::create([
+            'order_step_id' => $step->id,
+            'menu_id' => $menuB->id,
+            'quantity' => 1,
+            'status' => StepMenuStatus::SERVED,
+        ]);
+
+        $this->createOrderForUser($user, ['status' => OrderStatus::PENDING]);
+        $this->createOrderForUser($user, ['status' => OrderStatus::CANCELLED]);
+
+        $response = $this->actingAs($user)->graphQL(/** @lang GraphQL */ '{
+            ordersStats {
+                pending
+                in_prep
+                ready
+                served
+                payed
+                cancelled
+                total
+                revenue
+            }
+        }');
+
+        $response->assertJsonPath('data.ordersStats.pending', 1);
+        $response->assertJsonPath('data.ordersStats.payed', 1);
+        $response->assertJsonPath('data.ordersStats.cancelled', 1);
+        $response->assertJsonPath('data.ordersStats.total', 3);
+        $response->assertJsonPath('data.ordersStats.in_prep', 0);
+
+        $expectedRevenue = (12.5 * 2) + 5.25;
+        $this->assertEqualsWithDelta($expectedRevenue, $response->json('data.ordersStats.revenue'), 0.001);
+    }
+}

--- a/tests/Feature/OrderStepQueryTest.php
+++ b/tests/Feature/OrderStepQueryTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\OrderStatus;
+use App\Enums\OrderStepStatus;
+use App\Models\Order;
+use App\Models\OrderStep;
+use App\Models\Room;
+use App\Models\Table;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Tests\TestCase;
+
+class OrderStepQueryTest extends TestCase
+{
+    use MakesGraphQLRequests;
+    use RefreshDatabase;
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    private function createOrderForUser(User $user, array $attributes = []): Order
+    {
+        $room = Room::factory()->for($user->company)->create();
+        $table = Table::factory()->for($room, 'room')->for($user->company)->create();
+
+        $attributes = array_merge([
+            'table_id' => $table->id,
+            'company_id' => $user->company_id,
+            'user_id' => $user->id,
+            'status' => OrderStatus::PENDING,
+        ], $attributes);
+
+        return Order::create($attributes);
+    }
+
+    public function test_it_lists_order_steps_for_company(): void
+    {
+        $user = User::factory()->create();
+        $order = $this->createOrderForUser($user);
+        $step = OrderStep::create([
+            'order_id' => $order->id,
+            'name' => 'Service',
+            'position' => 1,
+            'status' => OrderStepStatus::PENDING,
+        ]);
+
+        $otherUser = User::factory()->create();
+        $otherOrder = $this->createOrderForUser($otherUser);
+        OrderStep::create([
+            'order_id' => $otherOrder->id,
+            'name' => 'Autre',
+            'position' => 1,
+            'status' => OrderStepStatus::READY,
+        ]);
+
+        $query = /** @lang GraphQL */ 'query ($orderId: ID!) {
+            orderSteps(order_id: $orderId) {
+                data { id }
+            }
+        }';
+
+        $response = $this->actingAs($user)->graphQL($query, ['orderId' => $order->id]);
+
+        $response->assertJsonCount(1, 'data.orderSteps.data');
+        $response->assertJsonFragment(['id' => (string) $step->id]);
+    }
+
+    public function test_it_filters_order_steps_by_status(): void
+    {
+        $user = User::factory()->create();
+        $order = $this->createOrderForUser($user);
+        $ready = OrderStep::create([
+            'order_id' => $order->id,
+            'name' => 'Prêt',
+            'position' => 1,
+            'status' => OrderStepStatus::READY,
+        ]);
+
+        OrderStep::create([
+            'order_id' => $order->id,
+            'name' => 'En attente',
+            'position' => 2,
+            'status' => OrderStepStatus::PENDING,
+        ]);
+
+        $query = /** @lang GraphQL */ 'query ($statuses: [OrderStepStatusEnum!]) {
+            orderSteps(statuses: $statuses) {
+                data { id status }
+            }
+        }';
+
+        $response = $this->actingAs($user)->graphQL($query, [
+            'statuses' => [OrderStepStatus::READY->value],
+        ]);
+
+        $response->assertJsonCount(1, 'data.orderSteps.data');
+        $response->assertJsonFragment([
+            'id' => (string) $ready->id,
+            'status' => OrderStepStatus::READY->value,
+        ]);
+    }
+
+    public function test_it_orders_steps_by_position_desc(): void
+    {
+        $user = User::factory()->create();
+        $order = $this->createOrderForUser($user);
+        $first = OrderStep::create([
+            'order_id' => $order->id,
+            'name' => 'Entrées',
+            'position' => 1,
+            'status' => OrderStepStatus::PENDING,
+        ]);
+
+        $second = OrderStep::create([
+            'order_id' => $order->id,
+            'name' => 'Plats',
+            'position' => 2,
+            'status' => OrderStepStatus::PENDING,
+        ]);
+
+        $response = $this->actingAs($user)->graphQL(/** @lang GraphQL */ '{
+            orderSteps(orderBy: [{column: POSITION, order: DESC}]) {
+                data { id }
+            }
+        }');
+
+        $response->assertJsonPath('data.orderSteps.data.0.id', (string) $second->id);
+        $response->assertJsonPath('data.orderSteps.data.1.id', (string) $first->id);
+    }
+
+    public function test_it_fetches_order_step_by_id(): void
+    {
+        $user = User::factory()->create();
+        $order = $this->createOrderForUser($user);
+        $step = OrderStep::create([
+            'order_id' => $order->id,
+            'name' => 'Service',
+            'position' => 1,
+            'status' => OrderStepStatus::READY,
+        ]);
+
+        $query = /** @lang GraphQL */ 'query ($id: ID!) {
+            orderStep(id: $id) { id status }
+        }';
+
+        $response = $this->actingAs($user)->graphQL($query, ['id' => $step->id]);
+
+        $response->assertJsonPath('data.orderStep.id', (string) $step->id);
+        $response->assertJsonPath('data.orderStep.status', OrderStepStatus::READY->value);
+    }
+}

--- a/tests/Feature/StepMenuQueryTest.php
+++ b/tests/Feature/StepMenuQueryTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\OrderStatus;
+use App\Enums\OrderStepStatus;
+use App\Enums\StepMenuStatus;
+use App\Models\Menu;
+use App\Models\Order;
+use App\Models\OrderStep;
+use App\Models\Room;
+use App\Models\StepMenu;
+use App\Models\Table;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Tests\TestCase;
+
+class StepMenuQueryTest extends TestCase
+{
+    use MakesGraphQLRequests;
+    use RefreshDatabase;
+
+    /**
+     * @param  array<string, mixed>  $orderAttributes
+     * @param  array<string, mixed>  $stepAttributes
+     */
+    private function createOrderStepForUser(User $user, array $orderAttributes = [], array $stepAttributes = []): OrderStep
+    {
+        $room = Room::factory()->for($user->company)->create();
+        $table = Table::factory()->for($room, 'room')->for($user->company)->create();
+
+        $order = Order::create(array_merge([
+            'table_id' => $table->id,
+            'company_id' => $user->company_id,
+            'user_id' => $user->id,
+            'status' => OrderStatus::PENDING,
+        ], $orderAttributes));
+
+        return OrderStep::create(array_merge([
+            'order_id' => $order->id,
+            'name' => 'Service',
+            'position' => 1,
+            'status' => OrderStepStatus::PENDING,
+        ], $stepAttributes));
+    }
+
+    public function test_it_lists_step_menus_for_company(): void
+    {
+        $user = User::factory()->create();
+        $step = $this->createOrderStepForUser($user);
+        $menu = Menu::factory()->for($user->company)->create();
+
+        $line = StepMenu::create([
+            'order_step_id' => $step->id,
+            'menu_id' => $menu->id,
+            'quantity' => 1,
+            'status' => StepMenuStatus::PENDING,
+        ]);
+
+        $otherUser = User::factory()->create();
+        $otherStep = $this->createOrderStepForUser($otherUser);
+        $otherMenu = Menu::factory()->for($otherUser->company)->create();
+
+        StepMenu::create([
+            'order_step_id' => $otherStep->id,
+            'menu_id' => $otherMenu->id,
+            'quantity' => 1,
+            'status' => StepMenuStatus::READY,
+        ]);
+
+        $query = /** @lang GraphQL */ 'query ($stepId: ID!) {
+            stepMenus(order_step_id: $stepId) {
+                data { id }
+            }
+        }';
+
+        $response = $this->actingAs($user)->graphQL($query, ['stepId' => $step->id]);
+
+        $response->assertJsonCount(1, 'data.stepMenus.data');
+        $response->assertJsonFragment(['id' => (string) $line->id]);
+    }
+
+    public function test_it_filters_step_menus_by_status(): void
+    {
+        $user = User::factory()->create();
+        $step = $this->createOrderStepForUser($user);
+        $menu = Menu::factory()->for($user->company)->create();
+
+        $ready = StepMenu::create([
+            'order_step_id' => $step->id,
+            'menu_id' => $menu->id,
+            'quantity' => 2,
+            'status' => StepMenuStatus::READY,
+        ]);
+
+        StepMenu::create([
+            'order_step_id' => $step->id,
+            'menu_id' => $menu->id,
+            'quantity' => 1,
+            'status' => StepMenuStatus::PENDING,
+        ]);
+
+        $query = /** @lang GraphQL */ 'query ($statuses: [StepMenuStatusEnum!]) {
+            stepMenus(statuses: $statuses) {
+                data { id status }
+            }
+        }';
+
+        $response = $this->actingAs($user)->graphQL($query, [
+            'statuses' => [StepMenuStatus::READY->value],
+        ]);
+
+        $response->assertJsonCount(1, 'data.stepMenus.data');
+        $response->assertJsonFragment([
+            'id' => (string) $ready->id,
+            'status' => StepMenuStatus::READY->value,
+        ]);
+    }
+
+    public function test_it_orders_step_menus_by_quantity_desc(): void
+    {
+        $user = User::factory()->create();
+        $step = $this->createOrderStepForUser($user);
+        $menuA = Menu::factory()->for($user->company)->create();
+        $menuB = Menu::factory()->for($user->company)->create();
+
+        $small = StepMenu::create([
+            'order_step_id' => $step->id,
+            'menu_id' => $menuA->id,
+            'quantity' => 1,
+            'status' => StepMenuStatus::PENDING,
+        ]);
+
+        $large = StepMenu::create([
+            'order_step_id' => $step->id,
+            'menu_id' => $menuB->id,
+            'quantity' => 4,
+            'status' => StepMenuStatus::PENDING,
+        ]);
+
+        $response = $this->actingAs($user)->graphQL(/** @lang GraphQL */ '{
+            stepMenus(orderBy: [{column: QUANTITY, order: DESC}]) {
+                data { id }
+            }
+        }');
+
+        $response->assertJsonPath('data.stepMenus.data.0.id', (string) $large->id);
+        $response->assertJsonPath('data.stepMenus.data.1.id', (string) $small->id);
+    }
+
+    public function test_it_fetches_step_menu_by_id(): void
+    {
+        $user = User::factory()->create();
+        $step = $this->createOrderStepForUser($user);
+        $menu = Menu::factory()->for($user->company)->create();
+
+        $line = StepMenu::create([
+            'order_step_id' => $step->id,
+            'menu_id' => $menu->id,
+            'quantity' => 3,
+            'status' => StepMenuStatus::SERVED,
+        ]);
+
+        $query = /** @lang GraphQL */ 'query ($id: ID!) {
+            stepMenu(id: $id) { id status quantity }
+        }';
+
+        $response = $this->actingAs($user)->graphQL($query, ['id' => $line->id]);
+
+        $response->assertJsonPath('data.stepMenu.id', (string) $line->id);
+        $response->assertJsonPath('data.stepMenu.status', StepMenuStatus::SERVED->value);
+        $response->assertJsonPath('data.stepMenu.quantity', 3);
+    }
+}


### PR DESCRIPTION
## Summary
- expose `Order`, `OrderStep` and `StepMenu` through dedicated Lighthouse schemas with filters, ordering clauses and order statistics
- register the missing enums and model scopes so the new GraphQL queries work with the authenticated company and optional date filters
- implement an OrdersResolver to compute status counts and revenue, and back everything with feature tests for the new queries

## Testing
- php artisan test
- ./vendor/bin/phpstan analyse --memory-limit=512M
- ./vendor/bin/pint

------
https://chatgpt.com/codex/tasks/task_e_68c9a230686c832d8b19865329797a9f