### PR TITLE
Rebuild demo seeder with OpenFoodFacts lookups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,13 @@ VENDOR_BIN = $(DC) exec $(APP) vendor/bin
 
 # Définition des cibles qui ne sont pas des fichiers
 .PHONY: help up down restart build exec shell status logs \
-		migrate migrate-fresh migrate-status \
-		seed rollback test tests coverage \
+	        migrate migrate-fresh migrate-status \
+	        seed demo-seed rollback test tests coverage \
 		cs pint larastan analyse \
 		install composer-update npm-update \
 		cache-clear optimize fresh reset-minio \
 		routes clean erd \
-        buildkhp-back-image
+	buildkhp-back-image
 
 # Cible par défaut
 .DEFAULT_GOAL := help
@@ -41,6 +41,7 @@ help:
 	@echo "  migrate-fresh : Rafraîchir la base de données"
 	@echo "  migrate-status: Vérifier le statut des migrations"
 	@echo "  seed          : Peupler la base de données"
+	@echo "  demo-seed     : Réinitialiser puis lancer le DemoSeeder"
 	@echo "  rollback      : Annuler la dernière migration"
 	@echo "--------------------------------"
 	@echo "Tests et Qualité de code :"
@@ -76,7 +77,7 @@ build:
 	$(DC) build
 
 buildkhp-back-image:
-    docker build --no-cache -t khp-back-builded:v0.0.1 -f docker/php/Dockerfile.production .
+	docker build --no-cache -t khp-back-builded:v0.0.1 -f docker/php/Dockerfile.production .
 
 exec shell:
 	$(DC) exec $(APP) bash
@@ -99,6 +100,12 @@ migrate-status:
 
 seed:
 	$(ARTISAN) db:seed
+
+demo-seed:
+	$(MAKE) reset-minio
+	$(ARTISAN) migrate:fresh
+	$(ARTISAN) db:seed --class=DemoSeeder
+	@echo "🍽️ Données de démonstration installées sur une base fraîche."
 
 rollback:
 	$(ARTISAN) migrate:rollback
@@ -163,4 +170,4 @@ clean: down
 
 erd:
 	$(ARTISAN) erd:generate
-    @echo "ERD diagram generated at localhost:8000/laravel-erd"
+	@echo "ERD diagram generated at localhost:8000/laravel-erd"

--- a/app/Services/ImageService.php
+++ b/app/Services/ImageService.php
@@ -107,31 +107,19 @@ class ImageService
 
     /**
      * S'assure qu'une image locale (par défaut le placeholder Laravel) est
-     * présente sur S3 à l'emplacement souhaité et renvoie ce chemin.
+     * présente sur S3 et renvoie son chemin.
      */
-    public function storePlaceholder(string $sourcePath = 'private/images/placeholder.svg', ?string $targetPath = null): string
+    public function storePlaceholder(string $path = 'private/images/placeholder.svg'): string
     {
-        $targetPath ??= $sourcePath;
-
-        if ($this->exists($targetPath)) {
-            return $targetPath;
+        if ($this->exists($path)) {
+            return $path;
         }
 
-        $localPath = storage_path('app/'.$sourcePath);
+        $localPath = storage_path('app/'.$path);
+        $contents = file_get_contents($localPath);
+        Storage::disk('s3')->put($path, $contents);
 
-        if (! is_file($localPath) || ! is_readable($localPath)) {
-            throw new \RuntimeException('Placeholder introuvable : '.$sourcePath);
-        }
-
-        $contents = @file_get_contents($localPath);
-
-        if ($contents === false) {
-            throw new \RuntimeException('Impossible de lire le placeholder local : '.$localPath);
-        }
-
-        Storage::disk('s3')->put($targetPath, $contents);
-
-        return $targetPath;
+        return $path;
     }
 
     public function exists(string $path): bool

--- a/database/seeders/DemoSeeder.php
+++ b/database/seeders/DemoSeeder.php
@@ -795,7 +795,7 @@ JSON;
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 600,
-            'stock' => 6,
+            'stock' => 0,
             'barcode' => '3770000648317',
         ],
         'Haricots verts frais' => [
@@ -1099,15 +1099,15 @@ JSON;
     ];
 
     private const PREPARATION_STOCK_LEVELS = [
-        'Pâté en croûte' => 0,
-        'Pickles de légumes' => 0,
-        'Brioche parisienne' => 0,
-        'Jus de marinière' => 0,
+        'Pâté en croûte' => 4,
+        'Pickles de légumes' => 6,
+        'Brioche parisienne' => 8,
+        'Jus de marinière' => 6,
         'Sole à la meunière' => 0,
-        'Cassolette d’artichauts' => 0,
-        'Millefeuille' => 0,
-        'Pêches pochées' => 0,
-        'Coulis de framboise' => 0,
+        'Cassolette d’artichauts' => 5,
+        'Millefeuille' => 10,
+        'Pêches pochées' => 6,
+        'Coulis de framboise' => 6,
     ];
 
     private ImageService $images;
@@ -1291,12 +1291,16 @@ JSON;
         foreach ($components as $component) {
             $name = null;
             $unit = null;
+            $quantity = 1.0;
 
             if (is_string($component)) {
                 $name = $component;
             } elseif (is_array($component)) {
                 $name = $component['name'] ?? null;
                 $unit = $component['unit'] ?? null;
+                if (array_key_exists('quantity', $component)) {
+                    $quantity = (float) $component['quantity'];
+                }
             }
 
             if (! is_string($name) || trim($name) === '') {
@@ -1320,7 +1324,7 @@ JSON;
 
             $normalized[] = [
                 'name' => $name,
-                'quantity' => 0.0,
+                'quantity' => max(0.0, $quantity),
                 'unit' => $unit,
             ];
         }

--- a/database/seeders/DemoSeeder.php
+++ b/database/seeders/DemoSeeder.php
@@ -603,7 +603,7 @@ JSON;
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 1000,
-            'stock' => 0,
+            'stock' => 6000,
             'barcode' => '4056489565536',
         ],
         'Beurre' => [
@@ -611,7 +611,7 @@ JSON;
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 250,
-            'stock' => 0,
+            'stock' => 3000,
             'barcode' => '26064413',
         ],
         'Eau' => [
@@ -619,7 +619,7 @@ JSON;
             'unit' => MeasurementUnit::LITRE,
             'base_unit' => MeasurementUnit::MILLILITRE,
             'base_quantity' => 1000,
-            'stock' => 0,
+            'stock' => 120,
             'barcode' => '1234500001857',
         ],
         'Sel' => [
@@ -627,7 +627,7 @@ JSON;
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 1000,
-            'stock' => 0,
+            'stock' => 1500,
             'barcode' => '10020811',
         ],
         'Échine de porc' => [
@@ -635,7 +635,7 @@ JSON;
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 180,
-            'stock' => 0,
+            'stock' => 12,
             'barcode' => '0207024022173',
         ],
         'Veau' => [
@@ -643,7 +643,7 @@ JSON;
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 160,
-            'stock' => 0,
+            'stock' => 10,
             'barcode' => '2695314012009',
         ],
         'Foie de volaille' => [
@@ -651,7 +651,7 @@ JSON;
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 90,
-            'stock' => 0,
+            'stock' => 18,
             'barcode' => '0215085018561',
         ],
         'Œufs' => [
@@ -659,7 +659,7 @@ JSON;
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::UNIT,
             'base_quantity' => 1,
-            'stock' => 0,
+            'stock' => 180,
             'barcode' => '3560070432080',
         ],
         'Crème' => [
@@ -667,7 +667,7 @@ JSON;
             'unit' => MeasurementUnit::LITRE,
             'base_unit' => MeasurementUnit::MILLILITRE,
             'base_quantity' => 1000,
-            'stock' => 0,
+            'stock' => 24,
             'barcode' => '3258561419299',
         ],
         'Poivre' => [
@@ -675,7 +675,7 @@ JSON;
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 250,
-            'stock' => 0,
+            'stock' => 300,
             'barcode' => '8720254531779',
         ],
         'Armagnac' => [
@@ -683,7 +683,7 @@ JSON;
             'unit' => MeasurementUnit::LITRE,
             'base_unit' => MeasurementUnit::MILLILITRE,
             'base_quantity' => 700,
-            'stock' => 0,
+            'stock' => 4.2,
             'barcode' => '3560070575480',
         ],
         'Épices' => [
@@ -691,7 +691,7 @@ JSON;
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 200,
-            'stock' => 0,
+            'stock' => 220,
             'barcode' => '3700483800544',
         ],
         'Fond de volaille' => [
@@ -699,7 +699,7 @@ JSON;
             'unit' => MeasurementUnit::LITRE,
             'base_unit' => MeasurementUnit::MILLILITRE,
             'base_quantity' => 1000,
-            'stock' => 0,
+            'stock' => 12,
             'barcode' => '3256225451647',
         ],
         'Gélatine' => [
@@ -707,7 +707,7 @@ JSON;
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 200,
-            'stock' => 0,
+            'stock' => 500,
             'barcode' => '3256225731978',
         ],
         'Carottes' => [
@@ -715,7 +715,7 @@ JSON;
             'unit' => MeasurementUnit::KILOGRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 1000,
-            'stock' => 0,
+            'stock' => 18,
             'barcode' => '3596710431151',
         ],
         'Chou-fleur' => [
@@ -723,7 +723,7 @@ JSON;
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 900,
-            'stock' => 0,
+            'stock' => 12,
             'barcode' => '3560070122349',
         ],
         'Oignons' => [
@@ -731,7 +731,7 @@ JSON;
             'unit' => MeasurementUnit::KILOGRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 1000,
-            'stock' => 0,
+            'stock' => 20,
             'barcode' => '3363290420116',
         ],
         'Cornichons' => [
@@ -739,7 +739,7 @@ JSON;
             'unit' => MeasurementUnit::KILOGRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 500,
-            'stock' => 0,
+            'stock' => 6,
             'barcode' => '4061464817722',
         ],
         'Vinaigre blanc' => [
@@ -747,7 +747,7 @@ JSON;
             'unit' => MeasurementUnit::LITRE,
             'base_unit' => MeasurementUnit::MILLILITRE,
             'base_quantity' => 1000,
-            'stock' => 0,
+            'stock' => 10,
             'barcode' => '3077311522405',
         ],
         'Sucre' => [
@@ -755,7 +755,7 @@ JSON;
             'unit' => MeasurementUnit::KILOGRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 1000,
-            'stock' => 0,
+            'stock' => 7000,
             'barcode' => '3596710473557',
         ],
         'Graines de moutarde' => [
@@ -763,7 +763,7 @@ JSON;
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 200,
-            'stock' => 0,
+            'stock' => 180,
             'barcode' => '7610845400434',
         ],
         'Foie gras de canard cru' => [
@@ -771,7 +771,7 @@ JSON;
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 500,
-            'stock' => 0,
+            'stock' => 6,
             'barcode' => '26078410',
         ],
         'Lait' => [
@@ -779,7 +779,7 @@ JSON;
             'unit' => MeasurementUnit::LITRE,
             'base_unit' => MeasurementUnit::MILLILITRE,
             'base_quantity' => 1000,
-            'stock' => 0,
+            'stock' => 40,
             'barcode' => '3428272970017',
         ],
         'Levure de boulanger' => [
@@ -787,7 +787,7 @@ JSON;
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 100,
-            'stock' => 0,
+            'stock' => 320,
             'barcode' => '2006050036622',
         ],
         'Homard bleu' => [
@@ -795,7 +795,7 @@ JSON;
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 600,
-            'stock' => 0,
+            'stock' => 6,
             'barcode' => '3770000648317',
         ],
         'Haricots verts frais' => [
@@ -803,7 +803,7 @@ JSON;
             'unit' => MeasurementUnit::KILOGRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 1000,
-            'stock' => 0,
+            'stock' => 10,
             'barcode' => '3760086270076',
         ],
         'Amandes fraîches' => [
@@ -811,7 +811,7 @@ JSON;
             'unit' => MeasurementUnit::KILOGRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 500,
-            'stock' => 0,
+            'stock' => 5,
             'barcode' => '3700194630287',
         ],
         'Huile d’olive' => [
@@ -819,7 +819,7 @@ JSON;
             'unit' => MeasurementUnit::LITRE,
             'base_unit' => MeasurementUnit::MILLILITRE,
             'base_quantity' => 1000,
-            'stock' => 0,
+            'stock' => 18,
             'barcode' => '3424096003078',
         ],
         'Citron' => [
@@ -827,7 +827,7 @@ JSON;
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 120,
-            'stock' => 0,
+            'stock' => 48,
             'barcode' => '3256226081881',
         ],
         'Tomate de plein champ' => [
@@ -835,7 +835,7 @@ JSON;
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 220,
-            'stock' => 0,
+            'stock' => 60,
             'barcode' => '3017800246658',
         ],
         'Filets d’anchois' => [
@@ -843,7 +843,7 @@ JSON;
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 500,
-            'stock' => 0,
+            'stock' => 400,
             'barcode' => '3218370591821',
         ],
         'Basilic frais' => [
@@ -851,7 +851,7 @@ JSON;
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 200,
-            'stock' => 0,
+            'stock' => 150,
             'barcode' => '3411061111029',
         ],
         'Dos de bar' => [
@@ -859,7 +859,7 @@ JSON;
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 280,
-            'stock' => 0,
+            'stock' => 8,
             'barcode' => '3664335055264',
         ],
         'Courgette trompette' => [
@@ -867,7 +867,7 @@ JSON;
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 200,
-            'stock' => 0,
+            'stock' => 30,
             'barcode' => '2306375001603',
         ],
         'Vin blanc sec' => [
@@ -875,7 +875,7 @@ JSON;
             'unit' => MeasurementUnit::LITRE,
             'base_unit' => MeasurementUnit::MILLILITRE,
             'base_quantity' => 750,
-            'stock' => 0,
+            'stock' => 18,
             'barcode' => '3660989151932',
         ],
         'Échalotes' => [
@@ -883,7 +883,7 @@ JSON;
             'unit' => MeasurementUnit::KILOGRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 1000,
-            'stock' => 0,
+            'stock' => 14,
             'barcode' => '8431876150353',
         ],
         'Persil' => [
@@ -891,7 +891,7 @@ JSON;
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 200,
-            'stock' => 0,
+            'stock' => 220,
             'barcode' => '2006050101283',
         ],
         'Sole' => [
@@ -899,7 +899,7 @@ JSON;
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 350,
-            'stock' => 0,
+            'stock' => 6,
             'barcode' => '0059749982474',
         ],
         'Jus de citron' => [
@@ -907,7 +907,7 @@ JSON;
             'unit' => MeasurementUnit::LITRE,
             'base_unit' => MeasurementUnit::MILLILITRE,
             'base_quantity' => 1000,
-            'stock' => 0,
+            'stock' => 12,
             'barcode' => '3564700299043',
         ],
         'Artichauts frais' => [
@@ -915,7 +915,7 @@ JSON;
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 320,
-            'stock' => 0,
+            'stock' => 20,
             'barcode' => '3256220652766',
         ],
         'Ail' => [
@@ -923,7 +923,7 @@ JSON;
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 60,
-            'stock' => 0,
+            'stock' => 30,
             'barcode' => '3256228100191',
         ],
         'Sucre glace' => [
@@ -931,7 +931,7 @@ JSON;
             'unit' => MeasurementUnit::KILOGRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 1000,
-            'stock' => 0,
+            'stock' => 3500,
             'barcode' => '3220035730001',
         ],
         'Gousse de vanille' => [
@@ -939,7 +939,7 @@ JSON;
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 6,
-            'stock' => 0,
+            'stock' => 60,
             'barcode' => '3256225732043',
         ],
         'Jaunes d’œuf' => [
@@ -947,7 +947,7 @@ JSON;
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::UNIT,
             'base_quantity' => 1,
-            'stock' => 0,
+            'stock' => 140,
             'barcode' => '3439496001838',
         ],
         'Fécule' => [
@@ -955,7 +955,7 @@ JSON;
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 500,
-            'stock' => 0,
+            'stock' => 700,
             'barcode' => '3347431805482',
         ],
         'Pêches' => [
@@ -963,7 +963,7 @@ JSON;
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 180,
-            'stock' => 0,
+            'stock' => 30,
             'barcode' => '3276559409466',
         ],
         'Sirop' => [
@@ -971,7 +971,7 @@ JSON;
             'unit' => MeasurementUnit::LITRE,
             'base_unit' => MeasurementUnit::MILLILITRE,
             'base_quantity' => 1000,
-            'stock' => 0,
+            'stock' => 16,
             'barcode' => '5708776000877',
         ],
         'Vanille' => [
@@ -979,7 +979,7 @@ JSON;
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 100,
-            'stock' => 0,
+            'stock' => 220,
             'barcode' => '6133798001790',
         ],
         'Framboises' => [
@@ -987,7 +987,7 @@ JSON;
             'unit' => MeasurementUnit::KILOGRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 1000,
-            'stock' => 0,
+            'stock' => 9,
             'barcode' => '3385630118309',
         ],
         'Glace vanille' => [
@@ -995,7 +995,7 @@ JSON;
             'unit' => MeasurementUnit::LITRE,
             'base_unit' => MeasurementUnit::MILLILITRE,
             'base_quantity' => 1000,
-            'stock' => 0,
+            'stock' => 20,
             'barcode' => '26048154',
         ],
         'Sélection de fromages de vache, chèvre, brebis' => [
@@ -1003,7 +1003,7 @@ JSON;
             'unit' => MeasurementUnit::KILOGRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 1500,
-            'stock' => 0,
+            'stock' => 14,
             'barcode' => '0200340018370',
         ],
     ];

--- a/database/seeders/DemoSeeder.php
+++ b/database/seeders/DemoSeeder.php
@@ -289,8 +289,6 @@ class DemoSeeder extends Seeder
 
     private const TEMP_IMAGE_FOLDER = 'tmp/demo-seeder/ingredients';
 
-    private const MENU_PLACEHOLDER_SOURCE = 'public/playsolder.png';
-
     private const DEFAULT_PLACEHOLDER_SOURCE = 'private/images/placeholder.svg';
 
     private const TEMP_PLACEHOLDER_PATH = 'tmp/demo-seeder/placeholder.svg';
@@ -526,13 +524,13 @@ class DemoSeeder extends Seeder
             return $this->placeholderImagePath;
         }
 
-        $localMenuPlaceholder = storage_path('app/'.self::MENU_PLACEHOLDER_SOURCE);
+        $localPlaceholder = storage_path('app/'.self::DEFAULT_PLACEHOLDER_SOURCE);
 
-        if (is_file($localMenuPlaceholder) && is_readable($localMenuPlaceholder)) {
+        if (is_file($localPlaceholder) && is_readable($localPlaceholder)) {
             try {
-                return $this->placeholderImagePath = $this->images->storePlaceholder(self::MENU_PLACEHOLDER_SOURCE);
+                return $this->placeholderImagePath = $this->images->storePlaceholder(self::DEFAULT_PLACEHOLDER_SOURCE);
             } catch (Throwable $exception) {
-                $this->command?->warn('Impossible d\'utiliser playsolder.png : '.$exception->getMessage());
+                $this->command?->warn('Impossible d\'utiliser le placeholder par défaut : '.$exception->getMessage());
             }
         }
 
@@ -540,7 +538,6 @@ class DemoSeeder extends Seeder
             return $this->placeholderImagePath = self::TEMP_PLACEHOLDER_PATH;
         }
 
-        $localPlaceholder = storage_path('app/'.self::DEFAULT_PLACEHOLDER_SOURCE);
         $contents = @file_get_contents($localPlaceholder);
 
         if ($contents !== false) {

--- a/database/seeders/DemoSeeder.php
+++ b/database/seeders/DemoSeeder.php
@@ -18,6 +18,7 @@ use App\Services\OpenFoodFactsService;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
+use JsonException;
 use RuntimeException;
 use Throwable;
 
@@ -35,207 +36,152 @@ class DemoSeeder extends Seeder
         ],
     ];
 
-    private const MENU_SECTIONS = [
-        'hors_doeuvres' => [
-            [
-                'name' => 'Notre pâté en croûte, pickles de légumes',
-                'price' => 28.0,
-                'ingredients' => [],
-                'preparations' => [
-                    [
-                        'name' => 'Pâté en croûte',
-                        'quantity' => 1,
-                        'unit' => MeasurementUnit::UNIT,
-                    ],
-                    [
-                        'name' => 'Pickles de légumes',
-                        'quantity' => 1,
-                        'unit' => MeasurementUnit::UNIT,
-                    ],
+    private const MENU_BLUEPRINT_JSON = <<<'JSON'
+{
+    "hors_doeuvres": [
+        {
+            "nom": "Notre pâté en croûte, pickles de légumes",
+            "prix": 28,
+            "preparations": {
+                "Pâté en croûte": [
+                    "Pâte brisée (farine, beurre, eau, sel)",
+                    "Farce de porc maison (échine de porc, veau, foie de volaille, œufs, crème, sel, poivre, armagnac, épices)",
+                    "Gelée (fond de volaille, gélatine)"
                 ],
+                "Pickles de légumes": [
+                    "Carottes",
+                    "Chou-fleur",
+                    "Oignons",
+                    "Cornichons",
+                    "Marinade (vinaigre blanc, eau, sucre, sel, graines de moutarde, poivre en grain)"
+                ]
+            }
+        },
+        {
+            "nom": "Foie gras de canard, brioche parisienne",
+            "prix": 32,
+            "ingredients": [
+                "Foie gras de canard cru"
             ],
-            [
-                'name' => 'Foie gras de canard, brioche parisienne',
-                'price' => 32.0,
-                'ingredients' => [
-                    [
-                        'name' => 'Foie gras de canard cru',
-                        'quantity' => 1,
-                        'unit' => MeasurementUnit::UNIT,
-                    ],
-                ],
-                'preparations' => [
-                    [
-                        'name' => 'Brioche parisienne',
-                        'quantity' => 1,
-                        'unit' => MeasurementUnit::UNIT,
-                    ],
-                ],
+            "preparations": {
+                "Brioche parisienne": [
+                    "Farine",
+                    "Œufs",
+                    "Beurre",
+                    "Lait",
+                    "Sucre",
+                    "Levure de boulanger",
+                    "Sel"
+                ]
+            }
+        },
+        {
+            "nom": "Homard bleu rafraîchi, haricots verts et amandes fraîches",
+            "prix": 38,
+            "ingredients": [
+                "Homard bleu",
+                "Haricots verts frais",
+                "Amandes fraîches",
+                "Huile d’olive",
+                "Citron",
+                "Sel",
+                "Poivre"
+            ]
+        },
+        {
+            "nom": "Tomate de plein champs fondante, anchois et basilic",
+            "prix": 30,
+            "ingredients": [
+                "Tomate de plein champ",
+                "Filets d’anchois",
+                "Basilic frais",
+                "Huile d’olive"
+            ]
+        }
+    ],
+    "plats": [
+        {
+            "nom": "Dos de bar doré, courgette trompette et jus d’une marinière",
+            "prix": 38,
+            "ingredients": [
+                "Dos de bar",
+                "Courgette trompette"
             ],
-            [
-                'name' => 'Homard bleu rafraîchi, haricots verts et amandes fraîches',
-                'price' => 38.0,
-                'ingredients' => [
-                    [
-                        'name' => 'Homard bleu',
-                        'quantity' => 1,
-                        'unit' => MeasurementUnit::UNIT,
-                    ],
-                    [
-                        'name' => 'Haricots verts frais',
-                        'quantity' => 200,
-                        'unit' => MeasurementUnit::GRAM,
-                    ],
-                    [
-                        'name' => 'Amandes fraîches',
-                        'quantity' => 40,
-                        'unit' => MeasurementUnit::GRAM,
-                    ],
-                    [
-                        'name' => 'Huile d’olive',
-                        'quantity' => 25,
-                        'unit' => MeasurementUnit::MILLILITRE,
-                    ],
-                    [
-                        'name' => 'Citron',
-                        'quantity' => 1,
-                        'unit' => MeasurementUnit::UNIT,
-                    ],
-                    [
-                        'name' => 'Sel',
-                        'quantity' => 2,
-                        'unit' => MeasurementUnit::GRAM,
-                    ],
-                    [
-                        'name' => 'Poivre',
-                        'quantity' => 1,
-                        'unit' => MeasurementUnit::GRAM,
-                    ],
+            "preparations": {
+                "Jus de marinière": [
+                    "Vin blanc sec",
+                    "Échalotes",
+                    "Beurre",
+                    "Persil",
+                    "Sel",
+                    "Poivre"
+                ]
+            }
+        },
+        {
+            "nom": "Sole à la meunière, cassolette d’artichauts (pour deux)",
+            "prix": 160,
+            "preparations": {
+                "Sole à la meunière": [
+                    "Sole",
+                    "Beurre",
+                    "Farine",
+                    "Jus de citron",
+                    "Persil"
                 ],
-                'preparations' => [],
-            ],
-            [
-                'name' => 'Tomate de plein champs fondante, anchois et basilic',
-                'price' => 30.0,
-                'ingredients' => [
-                    [
-                        'name' => 'Tomate de plein champ',
-                        'quantity' => 1,
-                        'unit' => MeasurementUnit::UNIT,
-                    ],
-                    [
-                        'name' => 'Filets d’anchois',
-                        'quantity' => 3,
-                        'unit' => MeasurementUnit::UNIT,
-                    ],
-                    [
-                        'name' => 'Basilic frais',
-                        'quantity' => 15,
-                        'unit' => MeasurementUnit::GRAM,
-                    ],
-                    [
-                        'name' => 'Huile d’olive',
-                        'quantity' => 20,
-                        'unit' => MeasurementUnit::MILLILITRE,
-                    ],
+                "Cassolette d’artichauts": [
+                    "Artichauts frais",
+                    "Fond de volaille",
+                    "Huile d’olive",
+                    "Ail",
+                    "Sel",
+                    "Poivre"
+                ]
+            }
+        }
+    ],
+    "fromage": [
+        {
+            "nom": "Fromages de France",
+            "prix": 16,
+            "ingredients": [
+                "Sélection de fromages de vache, chèvre, brebis"
+            ]
+        }
+    ],
+    "desserts": [
+        {
+            "nom": "Millefeuille classique à la vanille",
+            "prix": 14,
+            "preparations": {
+                "Millefeuille": [
+                    "Pâte feuilletée (farine, beurre, eau, sel)",
+                    "Crème pâtissière à la vanille (lait, sucre, jaunes d’œuf, fécule, gousse de vanille)",
+                    "Sucre glace"
+                ]
+            }
+        },
+        {
+            "nom": "Pêche Melba",
+            "prix": 14,
+            "preparations": {
+                "Pêches pochées": [
+                    "Pêches",
+                    "Sirop",
+                    "Vanille"
                 ],
-                'preparations' => [],
-            ],
-        ],
-        'plats' => [
-            [
-                'name' => 'Dos de bar doré, courgette trompette et jus d’une marinière',
-                'price' => 38.0,
-                'ingredients' => [
-                    [
-                        'name' => 'Dos de bar',
-                        'quantity' => 1,
-                        'unit' => MeasurementUnit::UNIT,
-                    ],
-                    [
-                        'name' => 'Courgette trompette',
-                        'quantity' => 1,
-                        'unit' => MeasurementUnit::UNIT,
-                    ],
-                ],
-                'preparations' => [
-                    [
-                        'name' => 'Jus de marinière',
-                        'quantity' => 1,
-                        'unit' => MeasurementUnit::UNIT,
-                    ],
-                ],
-            ],
-            [
-                'name' => 'Sole à la meunière, cassolette d’artichauts (pour deux)',
-                'price' => 160.0,
-                'ingredients' => [],
-                'preparations' => [
-                    [
-                        'name' => 'Sole à la meunière',
-                        'quantity' => 1,
-                        'unit' => MeasurementUnit::UNIT,
-                    ],
-                    [
-                        'name' => 'Cassolette d’artichauts',
-                        'quantity' => 1,
-                        'unit' => MeasurementUnit::UNIT,
-                    ],
-                ],
-            ],
-        ],
-        'fromage' => [
-            [
-                'name' => 'Fromages de France',
-                'price' => 16.0,
-                'ingredients' => [
-                    [
-                        'name' => 'Sélection de fromages de vache, chèvre, brebis',
-                        'quantity' => 1,
-                        'unit' => MeasurementUnit::UNIT,
-                    ],
-                ],
-                'preparations' => [],
-            ],
-        ],
-        'desserts' => [
-            [
-                'name' => 'Millefeuille classique à la vanille',
-                'price' => 14.0,
-                'ingredients' => [],
-                'preparations' => [
-                    [
-                        'name' => 'Millefeuille',
-                        'quantity' => 1,
-                        'unit' => MeasurementUnit::UNIT,
-                    ],
-                ],
-            ],
-            [
-                'name' => 'Pêche Melba',
-                'price' => 14.0,
-                'ingredients' => [
-                    [
-                        'name' => 'Glace vanille',
-                        'quantity' => 2,
-                        'unit' => MeasurementUnit::UNIT,
-                    ],
-                ],
-                'preparations' => [
-                    [
-                        'name' => 'Pêches pochées',
-                        'quantity' => 1,
-                        'unit' => MeasurementUnit::UNIT,
-                    ],
-                    [
-                        'name' => 'Coulis de framboise',
-                        'quantity' => 1,
-                        'unit' => MeasurementUnit::UNIT,
-                    ],
-                ],
-            ],
-        ],
-    ];
+                "Coulis de framboise": [
+                    "Framboises",
+                    "Sucre"
+                ]
+            },
+            "ingredients": [
+                "Glace vanille"
+            ]
+        }
+    ]
+}
+JSON;
 
     private const MENU_CATEGORY_LABELS = [
         'hors_doeuvres' => 'Entrées de la Maison',
@@ -657,7 +603,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 1000,
-            'stock' => 5000,
+            'stock' => 0,
             'barcode' => '4056489565536',
         ],
         'Beurre' => [
@@ -665,7 +611,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 250,
-            'stock' => 1500,
+            'stock' => 0,
             'barcode' => '26064413',
         ],
         'Eau' => [
@@ -673,7 +619,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::LITRE,
             'base_unit' => MeasurementUnit::MILLILITRE,
             'base_quantity' => 1000,
-            'stock' => 50,
+            'stock' => 0,
             'barcode' => '1234500001857',
         ],
         'Sel' => [
@@ -681,7 +627,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 1000,
-            'stock' => 2000,
+            'stock' => 0,
             'barcode' => '10020811',
         ],
         'Échine de porc' => [
@@ -689,7 +635,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 180,
-            'stock' => 24,
+            'stock' => 0,
             'barcode' => '0207024022173',
         ],
         'Veau' => [
@@ -697,7 +643,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 160,
-            'stock' => 18,
+            'stock' => 0,
             'barcode' => '2695314012009',
         ],
         'Foie de volaille' => [
@@ -705,7 +651,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 90,
-            'stock' => 40,
+            'stock' => 0,
             'barcode' => '0215085018561',
         ],
         'Œufs' => [
@@ -713,7 +659,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::UNIT,
             'base_quantity' => 1,
-            'stock' => 180,
+            'stock' => 0,
             'barcode' => '3560070432080',
         ],
         'Crème' => [
@@ -721,7 +667,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::LITRE,
             'base_unit' => MeasurementUnit::MILLILITRE,
             'base_quantity' => 1000,
-            'stock' => 18,
+            'stock' => 0,
             'barcode' => '3258561419299',
         ],
         'Poivre' => [
@@ -729,7 +675,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 250,
-            'stock' => 600,
+            'stock' => 0,
             'barcode' => '8720254531779',
         ],
         'Armagnac' => [
@@ -737,7 +683,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::LITRE,
             'base_unit' => MeasurementUnit::MILLILITRE,
             'base_quantity' => 700,
-            'stock' => 8,
+            'stock' => 0,
             'barcode' => '3560070575480',
         ],
         'Épices' => [
@@ -745,7 +691,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 200,
-            'stock' => 400,
+            'stock' => 0,
             'barcode' => '3700483800544',
         ],
         'Fond de volaille' => [
@@ -753,7 +699,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::LITRE,
             'base_unit' => MeasurementUnit::MILLILITRE,
             'base_quantity' => 1000,
-            'stock' => 15,
+            'stock' => 0,
             'barcode' => '3256225451647',
         ],
         'Gélatine' => [
@@ -761,7 +707,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 200,
-            'stock' => 300,
+            'stock' => 0,
             'barcode' => '3256225731978',
         ],
         'Carottes' => [
@@ -769,7 +715,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::KILOGRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 1000,
-            'stock' => 12,
+            'stock' => 0,
             'barcode' => '3596710431151',
         ],
         'Chou-fleur' => [
@@ -777,7 +723,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 900,
-            'stock' => 18,
+            'stock' => 0,
             'barcode' => '3560070122349',
         ],
         'Oignons' => [
@@ -785,7 +731,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::KILOGRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 1000,
-            'stock' => 10,
+            'stock' => 0,
             'barcode' => '3363290420116',
         ],
         'Cornichons' => [
@@ -793,7 +739,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::KILOGRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 500,
-            'stock' => 6,
+            'stock' => 0,
             'barcode' => '4061464817722',
         ],
         'Vinaigre blanc' => [
@@ -801,7 +747,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::LITRE,
             'base_unit' => MeasurementUnit::MILLILITRE,
             'base_quantity' => 1000,
-            'stock' => 20,
+            'stock' => 0,
             'barcode' => '3077311522405',
         ],
         'Sucre' => [
@@ -809,7 +755,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::KILOGRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 1000,
-            'stock' => 18,
+            'stock' => 0,
             'barcode' => '3596710473557',
         ],
         'Graines de moutarde' => [
@@ -817,7 +763,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 200,
-            'stock' => 350,
+            'stock' => 0,
             'barcode' => '7610845400434',
         ],
         'Foie gras de canard cru' => [
@@ -833,7 +779,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::LITRE,
             'base_unit' => MeasurementUnit::MILLILITRE,
             'base_quantity' => 1000,
-            'stock' => 30,
+            'stock' => 0,
             'barcode' => '3428272970017',
         ],
         'Levure de boulanger' => [
@@ -841,7 +787,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 100,
-            'stock' => 150,
+            'stock' => 0,
             'barcode' => '2006050036622',
         ],
         'Homard bleu' => [
@@ -857,7 +803,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::KILOGRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 1000,
-            'stock' => 14,
+            'stock' => 0,
             'barcode' => '3760086270076',
         ],
         'Amandes fraîches' => [
@@ -865,7 +811,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::KILOGRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 500,
-            'stock' => 8,
+            'stock' => 0,
             'barcode' => '3700194630287',
         ],
         'Huile d’olive' => [
@@ -873,7 +819,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::LITRE,
             'base_unit' => MeasurementUnit::MILLILITRE,
             'base_quantity' => 1000,
-            'stock' => 25,
+            'stock' => 0,
             'barcode' => '3424096003078',
         ],
         'Citron' => [
@@ -881,7 +827,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 120,
-            'stock' => 45,
+            'stock' => 0,
             'barcode' => '3256226081881',
         ],
         'Tomate de plein champ' => [
@@ -889,7 +835,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 220,
-            'stock' => 60,
+            'stock' => 0,
             'barcode' => '3017800246658',
         ],
         'Filets d’anchois' => [
@@ -897,7 +843,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 500,
-            'stock' => 750,
+            'stock' => 0,
             'barcode' => '3218370591821',
         ],
         'Basilic frais' => [
@@ -905,7 +851,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 200,
-            'stock' => 300,
+            'stock' => 0,
             'barcode' => '3411061111029',
         ],
         'Dos de bar' => [
@@ -913,7 +859,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 280,
-            'stock' => 16,
+            'stock' => 0,
             'barcode' => '3664335055264',
         ],
         'Courgette trompette' => [
@@ -921,7 +867,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 200,
-            'stock' => 32,
+            'stock' => 0,
             'barcode' => '2306375001603',
         ],
         'Vin blanc sec' => [
@@ -929,7 +875,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::LITRE,
             'base_unit' => MeasurementUnit::MILLILITRE,
             'base_quantity' => 750,
-            'stock' => 24,
+            'stock' => 0,
             'barcode' => '3660989151932',
         ],
         'Échalotes' => [
@@ -937,7 +883,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::KILOGRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 1000,
-            'stock' => 8,
+            'stock' => 0,
             'barcode' => '8431876150353',
         ],
         'Persil' => [
@@ -945,7 +891,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 200,
-            'stock' => 300,
+            'stock' => 0,
             'barcode' => '2006050101283',
         ],
         'Sole' => [
@@ -953,7 +899,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 350,
-            'stock' => 10,
+            'stock' => 0,
             'barcode' => '0059749982474',
         ],
         'Jus de citron' => [
@@ -961,7 +907,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::LITRE,
             'base_unit' => MeasurementUnit::MILLILITRE,
             'base_quantity' => 1000,
-            'stock' => 12,
+            'stock' => 0,
             'barcode' => '3564700299043',
         ],
         'Artichauts frais' => [
@@ -969,7 +915,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 320,
-            'stock' => 24,
+            'stock' => 0,
             'barcode' => '3256220652766',
         ],
         'Ail' => [
@@ -977,7 +923,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 60,
-            'stock' => 50,
+            'stock' => 0,
             'barcode' => '3256228100191',
         ],
         'Sucre glace' => [
@@ -985,7 +931,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::KILOGRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 1000,
-            'stock' => 6,
+            'stock' => 0,
             'barcode' => '3220035730001',
         ],
         'Gousse de vanille' => [
@@ -993,7 +939,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 6,
-            'stock' => 80,
+            'stock' => 0,
             'barcode' => '3256225732043',
         ],
         'Jaunes d’œuf' => [
@@ -1001,7 +947,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::UNIT,
             'base_quantity' => 1,
-            'stock' => 200,
+            'stock' => 0,
             'barcode' => '3439496001838',
         ],
         'Fécule' => [
@@ -1009,7 +955,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 500,
-            'stock' => 600,
+            'stock' => 0,
             'barcode' => '3347431805482',
         ],
         'Pêches' => [
@@ -1017,7 +963,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 180,
-            'stock' => 40,
+            'stock' => 0,
             'barcode' => '3276559409466',
         ],
         'Sirop' => [
@@ -1025,7 +971,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::LITRE,
             'base_unit' => MeasurementUnit::MILLILITRE,
             'base_quantity' => 1000,
-            'stock' => 18,
+            'stock' => 0,
             'barcode' => '5708776000877',
         ],
         'Vanille' => [
@@ -1033,7 +979,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::GRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 100,
-            'stock' => 250,
+            'stock' => 0,
             'barcode' => '6133798001790',
         ],
         'Framboises' => [
@@ -1041,7 +987,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::KILOGRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 1000,
-            'stock' => 12,
+            'stock' => 0,
             'barcode' => '3385630118309',
         ],
         'Glace vanille' => [
@@ -1049,7 +995,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::LITRE,
             'base_unit' => MeasurementUnit::MILLILITRE,
             'base_quantity' => 1000,
-            'stock' => 14,
+            'stock' => 0,
             'barcode' => '26048154',
         ],
         'Sélection de fromages de vache, chèvre, brebis' => [
@@ -1057,7 +1003,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::KILOGRAM,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 1500,
-            'stock' => 9,
+            'stock' => 0,
             'barcode' => '0200340018370',
         ],
     ];
@@ -1066,7 +1012,16 @@ class DemoSeeder extends Seeder
 
     private const DEFAULT_PLACEHOLDER_SOURCE = 'private/images/placeholder.svg';
 
-    private const DEMO_PLACEHOLDER_PATH = 'tmp/demo-seeder/placeholder.svg';
+    private const DEFAULT_PLACEHOLDER_DESTINATION = 'tmp/demo-seeder/placeholder.svg';
+
+    private const MENU_PLACEHOLDER_DESTINATION = 'tmp/demo-seeder/menu-placeholder.png';
+
+    private const MENU_PLACEHOLDER_SOURCES = [
+        'private/images/playsolder.png',
+        'private/images/placeholder.png',
+        'public/playsolder.png',
+        'public/placeholder.png',
+    ];
 
     private const DEFAULT_LOCATION_NAME = 'Chambre froide Maison Gustave';
 
@@ -1144,15 +1099,15 @@ class DemoSeeder extends Seeder
     ];
 
     private const PREPARATION_STOCK_LEVELS = [
-        'Pâté en croûte' => 24,
-        'Pickles de légumes' => 30,
-        'Brioche parisienne' => 36,
-        'Jus de marinière' => 40,
+        'Pâté en croûte' => 0,
+        'Pickles de légumes' => 0,
+        'Brioche parisienne' => 0,
+        'Jus de marinière' => 0,
         'Sole à la meunière' => 0,
-        'Cassolette d’artichauts' => 18,
-        'Millefeuille' => 30,
-        'Pêches pochées' => 24,
-        'Coulis de framboise' => 24,
+        'Cassolette d’artichauts' => 0,
+        'Millefeuille' => 0,
+        'Pêches pochées' => 0,
+        'Coulis de framboise' => 0,
     ];
 
     private ImageService $images;
@@ -1172,6 +1127,11 @@ class DemoSeeder extends Seeder
     private array $productImages = [];
 
     private ?string $placeholderImagePath = null;
+
+    /** @var array<string, array<int, array{name: string, price: float, ingredients: array<int, array{name: string, quantity: float, unit: MeasurementUnit}>, preparations: array<int, array{name: string, quantity: float, unit: MeasurementUnit}>>>|null */
+    private ?array $menuDataset = null;
+
+    private ?string $menuPlaceholderImagePath = null;
 
     /** @var array<string, int> */
     private array $ingredientLocations = [];
@@ -1223,9 +1183,11 @@ class DemoSeeder extends Seeder
             $ingredients
         );
         $menuCategories = $this->ensureMenuCategories($company);
+        $menuSections = $this->menuSections();
+
         $this->seedMenus(
             $company,
-            self::MENU_SECTIONS,
+            $menuSections,
             $menuCategories,
             $ingredients,
             $preparations,
@@ -1233,6 +1195,144 @@ class DemoSeeder extends Seeder
         );
 
         $this->report();
+    }
+
+    /**
+     * @return array<string, array<int, array{name: string, price: float, ingredients: array<int, array{name: string, quantity: float, unit: MeasurementUnit}>, preparations: array<int, array{name: string, quantity: float, unit: MeasurementUnit}>>>>
+     */
+    private function menuSections(): array
+    {
+        if ($this->menuDataset !== null) {
+            return $this->menuDataset;
+        }
+
+        try {
+            $decoded = json_decode(self::MENU_BLUEPRINT_JSON, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new RuntimeException('Impossible de décoder le jeu de données du menu de démonstration : '.$exception->getMessage(), 0, $exception);
+        }
+
+        if (! is_array($decoded)) {
+            return $this->menuDataset = [];
+        }
+
+        $sections = [];
+
+        foreach ($decoded as $sectionKey => $entries) {
+            if (! is_array($entries)) {
+                continue;
+            }
+
+            foreach ($entries as $entry) {
+                if (! is_array($entry)) {
+                    continue;
+                }
+
+                $name = $entry['nom'] ?? null;
+
+                if (! is_string($name) || trim($name) === '') {
+                    continue;
+                }
+
+                $price = isset($entry['prix']) ? (float) $entry['prix'] : 0.0;
+
+                $ingredients = $this->normalizeMenuComponents($entry['ingredients'] ?? [], false);
+                $preparations = $this->normalizeMenuComponents(
+                    $this->extractPreparationNames($entry['preparations'] ?? []),
+                    true
+                );
+
+                $sections[$sectionKey][] = [
+                    'name' => $name,
+                    'price' => $price,
+                    'ingredients' => $ingredients,
+                    'preparations' => $preparations,
+                ];
+            }
+        }
+
+        return $this->menuDataset = $sections;
+    }
+
+    /**
+     * @param  array<int|string, mixed>  $preparations
+     * @return array<int, string>
+     */
+    private function extractPreparationNames(array $preparations): array
+    {
+        $names = [];
+
+        foreach ($preparations as $key => $value) {
+            if (is_string($key) && trim($key) !== '') {
+                $names[] = $key;
+
+                continue;
+            }
+
+            if (is_string($value) && trim($value) !== '') {
+                $names[] = $value;
+
+                continue;
+            }
+
+            if (is_array($value)) {
+                $candidate = $value['name'] ?? null;
+
+                if (is_string($candidate) && trim($candidate) !== '') {
+                    $names[] = $candidate;
+                }
+            }
+        }
+
+        return array_values(array_unique($names));
+    }
+
+    /**
+     * @param  array<int|string, mixed>  $components
+     * @return array<int, array{name: string, quantity: float, unit: MeasurementUnit}>
+     */
+    private function normalizeMenuComponents(array $components, bool $forPreparations): array
+    {
+        $normalized = [];
+
+        foreach ($components as $component) {
+            $name = null;
+            $unit = null;
+
+            if (is_string($component)) {
+                $name = $component;
+            } elseif (is_array($component)) {
+                $name = $component['name'] ?? null;
+                $unit = $component['unit'] ?? null;
+            }
+
+            if (! is_string($name) || trim($name) === '') {
+                continue;
+            }
+
+            if ($forPreparations) {
+                $unit = $unit ?? MeasurementUnit::UNIT;
+            } else {
+                $definition = self::INGREDIENTS[$name] ?? null;
+                $unit = $unit ?? ($definition['unit'] ?? MeasurementUnit::UNIT);
+            }
+
+            if (! $unit instanceof MeasurementUnit) {
+                try {
+                    $unit = MeasurementUnit::from($unit);
+                } catch (\ValueError) {
+                    $unit = MeasurementUnit::UNIT;
+                }
+            }
+
+            $normalized[] = [
+                'name' => $name,
+                'quantity' => 0.0,
+                'unit' => $unit,
+            ];
+        }
+
+        return $normalized;
     }
 
     private function seedUsers(Company $company): ?User
@@ -1521,8 +1621,8 @@ class DemoSeeder extends Seeder
             return $this->placeholderImagePath;
         }
 
-        if ($this->images->exists(self::DEMO_PLACEHOLDER_PATH)) {
-            return $this->placeholderImagePath = self::DEMO_PLACEHOLDER_PATH;
+        if ($this->images->exists(self::DEFAULT_PLACEHOLDER_DESTINATION)) {
+            return $this->placeholderImagePath = self::DEFAULT_PLACEHOLDER_DESTINATION;
         }
 
         $localPlaceholder = storage_path('app/'.self::DEFAULT_PLACEHOLDER_SOURCE);
@@ -1535,8 +1635,8 @@ class DemoSeeder extends Seeder
                 $this->command?->warn('Impossible de lire le placeholder local pour la démonstration.');
             } else {
                 try {
-                    if (Storage::disk('s3')->put(self::DEMO_PLACEHOLDER_PATH, $contents)) {
-                        return $this->placeholderImagePath = self::DEMO_PLACEHOLDER_PATH;
+                    if (Storage::disk('s3')->put(self::DEFAULT_PLACEHOLDER_DESTINATION, $contents)) {
+                        return $this->placeholderImagePath = self::DEFAULT_PLACEHOLDER_DESTINATION;
                     }
 
                     $this->command?->warn('Impossible de stocker le placeholder de démonstration sur S3.');
@@ -1555,6 +1655,41 @@ class DemoSeeder extends Seeder
 
             return $this->placeholderImagePath = self::DEFAULT_PLACEHOLDER_SOURCE;
         }
+    }
+
+    private function menuPlaceholderPath(): string
+    {
+        if ($this->menuPlaceholderImagePath) {
+            return $this->menuPlaceholderImagePath;
+        }
+
+        if ($this->images->exists(self::MENU_PLACEHOLDER_DESTINATION)) {
+            return $this->menuPlaceholderImagePath = self::MENU_PLACEHOLDER_DESTINATION;
+        }
+
+        foreach (self::MENU_PLACEHOLDER_SOURCES as $candidate) {
+            $localPath = storage_path('app/'.$candidate);
+
+            if (! is_file($localPath) || ! is_readable($localPath)) {
+                continue;
+            }
+
+            $contents = file_get_contents($localPath);
+
+            if ($contents === false) {
+                continue;
+            }
+
+            try {
+                if (Storage::disk('s3')->put(self::MENU_PLACEHOLDER_DESTINATION, $contents)) {
+                    return $this->menuPlaceholderImagePath = self::MENU_PLACEHOLDER_DESTINATION;
+                }
+            } catch (Throwable $exception) {
+                $this->command?->warn('Impossible de stocker le placeholder menu à partir de '.$candidate.' : '.$exception->getMessage());
+            }
+        }
+
+        return $this->menuPlaceholderImagePath = $this->placeholderPath();
     }
 
     /**
@@ -1756,14 +1891,14 @@ class DemoSeeder extends Seeder
                 );
 
                 if (! $menu->image_url) {
-                    $menu->update(['image_url' => $this->placeholderPath()]);
+                    $menu->update(['image_url' => $this->menuPlaceholderPath()]);
                 }
 
                 if ($menuCategory instanceof MenuCategory) {
                     $menu->categories()->syncWithoutDetaching([$menuCategory->id]);
                 }
 
-                foreach ($entry['ingredients'] as $component) {
+                foreach (($entry['ingredients'] ?? []) as $component) {
                     $component = is_string($component) ? ['name' => $component] : $component;
                     $ingredientName = $component['name'] ?? null;
 
@@ -1805,7 +1940,7 @@ class DemoSeeder extends Seeder
                     );
                 }
 
-                foreach ($entry['preparations'] as $component) {
+                foreach (($entry['preparations'] ?? []) as $component) {
                     $component = is_string($component) ? ['name' => $component] : $component;
                     $preparationName = $component['name'] ?? null;
 

--- a/database/seeders/DemoSeeder.php
+++ b/database/seeders/DemoSeeder.php
@@ -289,6 +289,10 @@ class DemoSeeder extends Seeder
 
     private const TEMP_IMAGE_FOLDER = 'tmp/demo-seeder/ingredients';
 
+    private const MENU_PLACEHOLDER_SOURCE = 'public/playsolder.png';
+
+    private const DEFAULT_PLACEHOLDER_SOURCE = 'private/images/placeholder.svg';
+
     private const TEMP_PLACEHOLDER_PATH = 'tmp/demo-seeder/placeholder.svg';
 
     private ImageService $images;
@@ -522,11 +526,21 @@ class DemoSeeder extends Seeder
             return $this->placeholderImagePath;
         }
 
+        $localMenuPlaceholder = storage_path('app/'.self::MENU_PLACEHOLDER_SOURCE);
+
+        if (is_file($localMenuPlaceholder) && is_readable($localMenuPlaceholder)) {
+            try {
+                return $this->placeholderImagePath = $this->images->storePlaceholder(self::MENU_PLACEHOLDER_SOURCE);
+            } catch (Throwable $exception) {
+                $this->command?->warn('Impossible d\'utiliser playsolder.png : '.$exception->getMessage());
+            }
+        }
+
         if ($this->images->exists(self::TEMP_PLACEHOLDER_PATH)) {
             return $this->placeholderImagePath = self::TEMP_PLACEHOLDER_PATH;
         }
 
-        $localPlaceholder = storage_path('app/private/images/placeholder.svg');
+        $localPlaceholder = storage_path('app/'.self::DEFAULT_PLACEHOLDER_SOURCE);
         $contents = @file_get_contents($localPlaceholder);
 
         if ($contents !== false) {
@@ -539,7 +553,7 @@ class DemoSeeder extends Seeder
             }
         }
 
-        return $this->placeholderImagePath = $this->images->storePlaceholder();
+        return $this->placeholderImagePath = $this->images->storePlaceholder(self::DEFAULT_PLACEHOLDER_SOURCE);
     }
 
     /**

--- a/database/seeders/DemoSeeder.php
+++ b/database/seeders/DemoSeeder.php
@@ -39,25 +39,76 @@ class DemoSeeder extends Seeder
                 'name' => 'Notre pâté en croûte, pickles de légumes',
                 'price' => 28.0,
                 'ingredients' => [],
-                'preparations' => ['Pâté en croûte', 'Pickles de légumes'],
+                'preparations' => [
+                    [
+                        'name' => 'Pâté en croûte',
+                        'quantity' => 1,
+                        'unit' => MeasurementUnit::UNIT,
+                    ],
+                    [
+                        'name' => 'Pickles de légumes',
+                        'quantity' => 1,
+                        'unit' => MeasurementUnit::UNIT,
+                    ],
+                ],
             ],
             [
                 'name' => 'Foie gras de canard, brioche parisienne',
                 'price' => 32.0,
-                'ingredients' => ['Foie gras de canard cru'],
-                'preparations' => ['Brioche parisienne'],
+                'ingredients' => [
+                    [
+                        'name' => 'Foie gras de canard cru',
+                        'quantity' => 1,
+                        'unit' => MeasurementUnit::UNIT,
+                    ],
+                ],
+                'preparations' => [
+                    [
+                        'name' => 'Brioche parisienne',
+                        'quantity' => 1,
+                        'unit' => MeasurementUnit::UNIT,
+                    ],
+                ],
             ],
             [
                 'name' => 'Homard bleu rafraîchi, haricots verts et amandes fraîches',
                 'price' => 38.0,
                 'ingredients' => [
-                    'Homard bleu',
-                    'Haricots verts frais',
-                    'Amandes fraîches',
-                    'Huile d’olive',
-                    'Citron',
-                    'Sel',
-                    'Poivre',
+                    [
+                        'name' => 'Homard bleu',
+                        'quantity' => 1,
+                        'unit' => MeasurementUnit::UNIT,
+                    ],
+                    [
+                        'name' => 'Haricots verts frais',
+                        'quantity' => 200,
+                        'unit' => MeasurementUnit::GRAM,
+                    ],
+                    [
+                        'name' => 'Amandes fraîches',
+                        'quantity' => 40,
+                        'unit' => MeasurementUnit::GRAM,
+                    ],
+                    [
+                        'name' => 'Huile d’olive',
+                        'quantity' => 25,
+                        'unit' => MeasurementUnit::MILLILITRE,
+                    ],
+                    [
+                        'name' => 'Citron',
+                        'quantity' => 1,
+                        'unit' => MeasurementUnit::UNIT,
+                    ],
+                    [
+                        'name' => 'Sel',
+                        'quantity' => 2,
+                        'unit' => MeasurementUnit::GRAM,
+                    ],
+                    [
+                        'name' => 'Poivre',
+                        'quantity' => 1,
+                        'unit' => MeasurementUnit::GRAM,
+                    ],
                 ],
                 'preparations' => [],
             ],
@@ -65,10 +116,26 @@ class DemoSeeder extends Seeder
                 'name' => 'Tomate de plein champs fondante, anchois et basilic',
                 'price' => 30.0,
                 'ingredients' => [
-                    'Tomate de plein champ',
-                    'Filets d’anchois',
-                    'Basilic frais',
-                    'Huile d’olive',
+                    [
+                        'name' => 'Tomate de plein champ',
+                        'quantity' => 1,
+                        'unit' => MeasurementUnit::UNIT,
+                    ],
+                    [
+                        'name' => 'Filets d’anchois',
+                        'quantity' => 3,
+                        'unit' => MeasurementUnit::UNIT,
+                    ],
+                    [
+                        'name' => 'Basilic frais',
+                        'quantity' => 15,
+                        'unit' => MeasurementUnit::GRAM,
+                    ],
+                    [
+                        'name' => 'Huile d’olive',
+                        'quantity' => 20,
+                        'unit' => MeasurementUnit::MILLILITRE,
+                    ],
                 ],
                 'preparations' => [],
             ],
@@ -77,21 +144,55 @@ class DemoSeeder extends Seeder
             [
                 'name' => 'Dos de bar doré, courgette trompette et jus d’une marinière',
                 'price' => 38.0,
-                'ingredients' => ['Dos de bar', 'Courgette trompette'],
-                'preparations' => ['Jus de marinière'],
+                'ingredients' => [
+                    [
+                        'name' => 'Dos de bar',
+                        'quantity' => 1,
+                        'unit' => MeasurementUnit::UNIT,
+                    ],
+                    [
+                        'name' => 'Courgette trompette',
+                        'quantity' => 1,
+                        'unit' => MeasurementUnit::UNIT,
+                    ],
+                ],
+                'preparations' => [
+                    [
+                        'name' => 'Jus de marinière',
+                        'quantity' => 1,
+                        'unit' => MeasurementUnit::UNIT,
+                    ],
+                ],
             ],
             [
                 'name' => 'Sole à la meunière, cassolette d’artichauts (pour deux)',
                 'price' => 160.0,
                 'ingredients' => [],
-                'preparations' => ['Sole à la meunière', 'Cassolette d’artichauts'],
+                'preparations' => [
+                    [
+                        'name' => 'Sole à la meunière',
+                        'quantity' => 1,
+                        'unit' => MeasurementUnit::UNIT,
+                    ],
+                    [
+                        'name' => 'Cassolette d’artichauts',
+                        'quantity' => 1,
+                        'unit' => MeasurementUnit::UNIT,
+                    ],
+                ],
             ],
         ],
         'fromage' => [
             [
                 'name' => 'Fromages de France',
                 'price' => 16.0,
-                'ingredients' => ['Sélection de fromages de vache, chèvre, brebis'],
+                'ingredients' => [
+                    [
+                        'name' => 'Sélection de fromages de vache, chèvre, brebis',
+                        'quantity' => 1,
+                        'unit' => MeasurementUnit::UNIT,
+                    ],
+                ],
                 'preparations' => [],
             ],
         ],
@@ -100,13 +201,36 @@ class DemoSeeder extends Seeder
                 'name' => 'Millefeuille classique à la vanille',
                 'price' => 14.0,
                 'ingredients' => [],
-                'preparations' => ['Millefeuille'],
+                'preparations' => [
+                    [
+                        'name' => 'Millefeuille',
+                        'quantity' => 1,
+                        'unit' => MeasurementUnit::UNIT,
+                    ],
+                ],
             ],
             [
                 'name' => 'Pêche Melba',
                 'price' => 14.0,
-                'ingredients' => ['Glace vanille'],
-                'preparations' => ['Pêches pochées', 'Coulis de framboise'],
+                'ingredients' => [
+                    [
+                        'name' => 'Glace vanille',
+                        'quantity' => 2,
+                        'unit' => MeasurementUnit::UNIT,
+                    ],
+                ],
+                'preparations' => [
+                    [
+                        'name' => 'Pêches pochées',
+                        'quantity' => 1,
+                        'unit' => MeasurementUnit::UNIT,
+                    ],
+                    [
+                        'name' => 'Coulis de framboise',
+                        'quantity' => 1,
+                        'unit' => MeasurementUnit::UNIT,
+                    ],
+                ],
             ],
         ],
     ];
@@ -1095,7 +1219,6 @@ class DemoSeeder extends Seeder
                     : MeasurementUnit::from($meta['base_unit']))
                 : $unit;
             $baseQuantity = isset($meta['base_quantity']) ? (float) $meta['base_quantity'] : 0.0;
-            $stockQuantity = isset($meta['stock']) ? (float) $meta['stock'] : $baseQuantity;
 
             $ingredient = Ingredient::updateOrCreate(
                 [
@@ -1123,7 +1246,7 @@ class DemoSeeder extends Seeder
             }
 
             $ingredient->locations()->syncWithoutDetaching([
-                $defaultLocation->id => ['quantity' => $stockQuantity],
+                $defaultLocation->id,
             ]);
 
             $ingredients[$name] = $ingredient;
@@ -1284,7 +1407,7 @@ class DemoSeeder extends Seeder
         );
 
         $preparation->locations()->syncWithoutDetaching([
-            $defaultLocation->id => ['quantity' => 1],
+            $defaultLocation->id,
         ]);
 
         $preparation->entities()->delete();
@@ -1376,7 +1499,12 @@ class DemoSeeder extends Seeder
      * @param  array<string, MenuCategory>  $menuCategories
      * @param  array<string, Ingredient>  $ingredients
      * @param  array<string, Preparation>  $preparations
-     * @param  array<string, array<int, array{name: string, price: float, ingredients: array<int, string>, preparations: array<int, string>}>>  $dataset
+     * @param  array<string, array<int, array{
+     *     name: string,
+     *     price: float,
+     *     ingredients: array<int, array{name: string, quantity?: float, unit?: MeasurementUnit|string}>,
+     *     preparations: array<int, array{name: string, quantity?: float, unit?: MeasurementUnit|string}>,
+     * }>>  $dataset
      */
     private function seedMenus(
         Company $company,
@@ -1412,7 +1540,14 @@ class DemoSeeder extends Seeder
                     $menu->categories()->syncWithoutDetaching([$menuCategory->id]);
                 }
 
-                foreach ($entry['ingredients'] as $ingredientName) {
+                foreach ($entry['ingredients'] as $component) {
+                    $component = is_string($component) ? ['name' => $component] : $component;
+                    $ingredientName = $component['name'] ?? null;
+
+                    if (! $ingredientName) {
+                        continue;
+                    }
+
                     $ingredient = $ingredients[$ingredientName] ?? null;
                     if (! $ingredient) {
                         $this->missingComponents[] = $ingredientName.' (menu '.$entry['name'].')';
@@ -1420,7 +1555,14 @@ class DemoSeeder extends Seeder
                         continue;
                     }
 
-                    $locationId = $ingredient->locations()->first()?->id ?? $defaultLocation->id;
+                    $quantity = array_key_exists('quantity', $component)
+                        ? (float) $component['quantity']
+                        : 1.0;
+
+                    $componentUnit = $component['unit'] ?? $ingredient->unit ?? MeasurementUnit::UNIT;
+                    $componentUnit = $componentUnit instanceof MeasurementUnit
+                        ? $componentUnit
+                        : MeasurementUnit::from($componentUnit);
 
                     MenuItem::updateOrCreate(
                         [
@@ -1429,14 +1571,21 @@ class DemoSeeder extends Seeder
                             'entity_type' => Ingredient::class,
                         ],
                         [
-                            'location_id' => $locationId,
-                            'quantity' => 0,
-                            'unit' => $ingredient->unit->value,
+                            'location_id' => $defaultLocation->id,
+                            'quantity' => $quantity,
+                            'unit' => $componentUnit->value,
                         ]
                     );
                 }
 
-                foreach ($entry['preparations'] as $preparationName) {
+                foreach ($entry['preparations'] as $component) {
+                    $component = is_string($component) ? ['name' => $component] : $component;
+                    $preparationName = $component['name'] ?? null;
+
+                    if (! $preparationName) {
+                        continue;
+                    }
+
                     $preparation = $preparations[$preparationName] ?? null;
                     if (! $preparation) {
                         $this->missingComponents[] = $preparationName.' (menu '.$entry['name'].')';
@@ -1444,7 +1593,14 @@ class DemoSeeder extends Seeder
                         continue;
                     }
 
-                    $locationId = $preparation->locations()->first()?->id ?? $defaultLocation->id;
+                    $quantity = array_key_exists('quantity', $component)
+                        ? (float) $component['quantity']
+                        : 1.0;
+
+                    $componentUnit = $component['unit'] ?? MeasurementUnit::UNIT;
+                    $componentUnit = $componentUnit instanceof MeasurementUnit
+                        ? $componentUnit
+                        : MeasurementUnit::from($componentUnit);
 
                     MenuItem::updateOrCreate(
                         [
@@ -1453,9 +1609,9 @@ class DemoSeeder extends Seeder
                             'entity_type' => Preparation::class,
                         ],
                         [
-                            'location_id' => $locationId,
-                            'quantity' => 0,
-                            'unit' => MeasurementUnit::UNIT->value,
+                            'location_id' => $defaultLocation->id,
+                            'quantity' => $quantity,
+                            'unit' => $componentUnit->value,
                         ]
                     );
                 }

--- a/database/seeders/DemoSeeder.php
+++ b/database/seeders/DemoSeeder.php
@@ -1,0 +1,745 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\MeasurementUnit;
+use App\Models\Category;
+use App\Models\Company;
+use App\Models\Ingredient;
+use App\Models\Location;
+use App\Models\Menu;
+use App\Models\MenuCategory;
+use App\Models\MenuItem;
+use App\Models\Preparation;
+use App\Models\User;
+use App\Services\ImageService;
+use App\Services\OpenFoodFactsService;
+use Illuminate\Database\Seeder;
+use Throwable;
+
+class DemoSeeder extends Seeder
+{
+    private const COMPANY_PROFILE = [
+        'name' => 'Maison Gustave',
+        'open_food_facts_language' => 'fr',
+        'users' => [
+            ['name' => 'Adrien', 'email' => 'adrien@gmail.com'],
+            ['name' => 'Thomas', 'email' => 'thomas@gmail.com'],
+            ['name' => 'Luca', 'email' => 'luca@gmail.com'],
+            ['name' => 'Brandon', 'email' => 'brandon@gmail.com'],
+            ['name' => 'Antoine', 'email' => 'antoine@gmail.com'],
+        ],
+    ];
+
+    private const MENU_SECTIONS = [
+        'hors_doeuvres' => [
+            [
+                'name' => 'Notre pâté en croûte, pickles de légumes',
+                'price' => 28.0,
+                'ingredients' => [],
+                'preparations' => ['Pâté en croûte', 'Pickles de légumes'],
+            ],
+            [
+                'name' => 'Foie gras de canard, brioche parisienne',
+                'price' => 32.0,
+                'ingredients' => ['Foie gras de canard cru'],
+                'preparations' => ['Brioche parisienne'],
+            ],
+            [
+                'name' => 'Homard bleu rafraîchi, haricots verts et amandes fraîches',
+                'price' => 38.0,
+                'ingredients' => [
+                    'Homard bleu',
+                    'Haricots verts frais',
+                    'Amandes fraîches',
+                    'Huile d’olive',
+                    'Citron',
+                    'Sel',
+                    'Poivre',
+                ],
+                'preparations' => [],
+            ],
+            [
+                'name' => 'Tomate de plein champs fondante, anchois et basilic',
+                'price' => 30.0,
+                'ingredients' => [
+                    'Tomate de plein champ',
+                    'Filets d’anchois',
+                    'Basilic frais',
+                    'Huile d’olive',
+                ],
+                'preparations' => [],
+            ],
+        ],
+        'plats' => [
+            [
+                'name' => 'Dos de bar doré, courgette trompette et jus d’une marinière',
+                'price' => 38.0,
+                'ingredients' => ['Dos de bar', 'Courgette trompette'],
+                'preparations' => ['Jus de marinière'],
+            ],
+            [
+                'name' => 'Sole à la meunière, cassolette d’artichauts (pour deux)',
+                'price' => 160.0,
+                'ingredients' => [],
+                'preparations' => ['Sole à la meunière', 'Cassolette d’artichauts'],
+            ],
+        ],
+        'fromage' => [
+            [
+                'name' => 'Fromages de France',
+                'price' => 16.0,
+                'ingredients' => ['Sélection de fromages de vache, chèvre, brebis'],
+                'preparations' => [],
+            ],
+        ],
+        'desserts' => [
+            [
+                'name' => 'Millefeuille classique à la vanille',
+                'price' => 14.0,
+                'ingredients' => [],
+                'preparations' => ['Millefeuille'],
+            ],
+            [
+                'name' => 'Pêche Melba',
+                'price' => 14.0,
+                'ingredients' => ['Glace vanille'],
+                'preparations' => ['Pêches pochées', 'Coulis de framboise'],
+            ],
+        ],
+    ];
+
+    private const MENU_CATEGORY_LABELS = [
+        'hors_doeuvres' => 'Entrées de la Maison',
+        'plats' => 'Plats Signature',
+        'fromage' => 'Sélection Fromagère',
+        'desserts' => 'Douceurs sucrées',
+    ];
+
+    private const MENU_TYPE_MAP = [
+        'hors_doeuvres' => 'entrée',
+        'plats' => 'plat',
+        'fromage' => 'dessert',
+        'desserts' => 'dessert',
+    ];
+
+    private const PREPARATION_COMPONENTS = [
+        'Pâte brisée' => [
+            ['ingredient' => 'Farine'],
+            ['ingredient' => 'Beurre'],
+            ['ingredient' => 'Eau'],
+            ['ingredient' => 'Sel'],
+        ],
+        'Farce de porc maison' => [
+            ['ingredient' => 'Échine de porc'],
+            ['ingredient' => 'Veau'],
+            ['ingredient' => 'Foie de volaille'],
+            ['ingredient' => 'Œufs'],
+            ['ingredient' => 'Crème'],
+            ['ingredient' => 'Sel'],
+            ['ingredient' => 'Poivre'],
+            ['ingredient' => 'Armagnac'],
+            ['ingredient' => 'Épices'],
+        ],
+        'Gelée' => [
+            ['ingredient' => 'Fond de volaille'],
+            ['ingredient' => 'Gélatine'],
+        ],
+        'Pâté en croûte' => [
+            ['preparation' => 'Pâte brisée'],
+            ['preparation' => 'Farce de porc maison'],
+            ['preparation' => 'Gelée'],
+        ],
+        'Marinade' => [
+            ['ingredient' => 'Vinaigre blanc'],
+            ['ingredient' => 'Eau'],
+            ['ingredient' => 'Sucre'],
+            ['ingredient' => 'Sel'],
+            ['ingredient' => 'Graines de moutarde'],
+            ['ingredient' => 'Poivre'],
+        ],
+        'Pickles de légumes' => [
+            ['ingredient' => 'Carottes'],
+            ['ingredient' => 'Chou-fleur'],
+            ['ingredient' => 'Oignons'],
+            ['ingredient' => 'Cornichons'],
+            ['preparation' => 'Marinade'],
+        ],
+        'Brioche parisienne' => [
+            ['ingredient' => 'Farine'],
+            ['ingredient' => 'Œufs'],
+            ['ingredient' => 'Beurre'],
+            ['ingredient' => 'Lait'],
+            ['ingredient' => 'Sucre'],
+            ['ingredient' => 'Levure de boulanger'],
+            ['ingredient' => 'Sel'],
+        ],
+        'Jus de marinière' => [
+            ['ingredient' => 'Vin blanc sec'],
+            ['ingredient' => 'Échalotes'],
+            ['ingredient' => 'Beurre'],
+            ['ingredient' => 'Persil'],
+            ['ingredient' => 'Sel'],
+            ['ingredient' => 'Poivre'],
+        ],
+        'Sole à la meunière' => [
+            ['ingredient' => 'Sole'],
+            ['ingredient' => 'Beurre'],
+            ['ingredient' => 'Farine'],
+            ['ingredient' => 'Jus de citron'],
+            ['ingredient' => 'Persil'],
+        ],
+        'Cassolette d’artichauts' => [
+            ['ingredient' => 'Artichauts frais'],
+            ['ingredient' => 'Fond de volaille'],
+            ['ingredient' => 'Huile d’olive'],
+            ['ingredient' => 'Ail'],
+            ['ingredient' => 'Sel'],
+            ['ingredient' => 'Poivre'],
+        ],
+        'Pâte feuilletée' => [
+            ['ingredient' => 'Farine'],
+            ['ingredient' => 'Beurre'],
+            ['ingredient' => 'Eau'],
+            ['ingredient' => 'Sel'],
+        ],
+        'Crème pâtissière à la vanille' => [
+            ['ingredient' => 'Lait'],
+            ['ingredient' => 'Sucre'],
+            ['ingredient' => 'Jaunes d’œuf'],
+            ['ingredient' => 'Fécule'],
+            ['ingredient' => 'Gousse de vanille'],
+        ],
+        'Millefeuille' => [
+            ['preparation' => 'Pâte feuilletée'],
+            ['preparation' => 'Crème pâtissière à la vanille'],
+            ['ingredient' => 'Sucre glace'],
+        ],
+        'Pêches pochées' => [
+            ['ingredient' => 'Pêches'],
+            ['ingredient' => 'Sirop'],
+            ['ingredient' => 'Vanille'],
+        ],
+        'Coulis de framboise' => [
+            ['ingredient' => 'Framboises'],
+            ['ingredient' => 'Sucre'],
+        ],
+        'Pêche Melba' => [
+            ['preparation' => 'Pêches pochées'],
+            ['preparation' => 'Coulis de framboise'],
+            ['ingredient' => 'Glace vanille'],
+        ],
+    ];
+
+    private const INGREDIENTS = [
+        'Farine' => ['category' => 'Farines', 'unit' => MeasurementUnit::GRAM, 'barcode' => '4056489565536'],
+        'Beurre' => ['category' => 'Produits Laitiers', 'unit' => MeasurementUnit::GRAM, 'barcode' => '26064413'],
+        'Eau' => ['category' => 'Boissons', 'unit' => MeasurementUnit::LITRE, 'barcode' => '1234500001857'],
+        'Sel' => ['category' => 'Épicerie', 'unit' => MeasurementUnit::GRAM, 'barcode' => '10020811'],
+        'Échine de porc' => ['category' => 'Viandes', 'unit' => MeasurementUnit::GRAM, 'barcode' => '0207024022173'],
+        'Veau' => ['category' => 'Viandes', 'unit' => MeasurementUnit::GRAM, 'barcode' => '2695314012009'],
+        'Foie de volaille' => ['category' => 'Viandes', 'unit' => MeasurementUnit::GRAM, 'barcode' => '0215085018561'],
+        'Œufs' => ['category' => 'Œufs', 'unit' => MeasurementUnit::UNIT, 'barcode' => '3560070432080'],
+        'Crème' => ['category' => 'Produits Laitiers', 'unit' => MeasurementUnit::LITRE, 'barcode' => '3258561419299'],
+        'Poivre' => ['category' => 'Épices', 'unit' => MeasurementUnit::GRAM, 'barcode' => '8720254531779'],
+        'Armagnac' => ['category' => 'Spiritueux', 'unit' => MeasurementUnit::LITRE, 'barcode' => '3560070575480'],
+        'Épices' => ['category' => 'Épices', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3700483800544'],
+        'Fond de volaille' => ['category' => 'Épicerie', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3256225451647'],
+        'Gélatine' => ['category' => 'Épicerie', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3256225731978'],
+        'Carottes' => ['category' => 'Légumes', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3596710431151'],
+        'Chou-fleur' => ['category' => 'Légumes', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3560070122349'],
+        'Oignons' => ['category' => 'Légumes', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3363290420116'],
+        'Cornichons' => ['category' => 'Épicerie', 'unit' => MeasurementUnit::GRAM, 'barcode' => '4061464817722'],
+        'Vinaigre blanc' => ['category' => 'Épicerie', 'unit' => MeasurementUnit::LITRE, 'barcode' => '3077311522405'],
+        'Sucre' => ['category' => 'Épicerie', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3596710473557'],
+        'Graines de moutarde' => ['category' => 'Épices', 'unit' => MeasurementUnit::GRAM, 'barcode' => '7610845400434'],
+        'Foie gras de canard cru' => ['category' => 'Viandes', 'unit' => MeasurementUnit::GRAM, 'barcode' => '26078410'],
+        'Lait' => ['category' => 'Produits Laitiers', 'unit' => MeasurementUnit::LITRE, 'barcode' => '3428272970017'],
+        'Levure de boulanger' => ['category' => 'Épicerie', 'unit' => MeasurementUnit::GRAM, 'barcode' => '2006050036622'],
+        'Homard bleu' => ['category' => 'Fruits de Mer', 'unit' => MeasurementUnit::UNIT, 'barcode' => '3770000648317'],
+        'Haricots verts frais' => ['category' => 'Légumes', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3760086270076'],
+        'Amandes fraîches' => ['category' => 'Fruits secs', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3700194630287'],
+        'Huile d’olive' => ['category' => 'Épicerie', 'unit' => MeasurementUnit::LITRE, 'barcode' => '3424096003078'],
+        'Citron' => ['category' => 'Fruits', 'unit' => MeasurementUnit::UNIT, 'barcode' => '3256226081881'],
+        'Tomate de plein champ' => ['category' => 'Légumes', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3017800246658'],
+        'Filets d’anchois' => ['category' => 'Poissons', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3218370591821'],
+        'Basilic frais' => ['category' => 'Herbes aromatiques', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3411061111029'],
+        'Dos de bar' => ['category' => 'Poissons', 'unit' => MeasurementUnit::UNIT, 'barcode' => '3664335055264'],
+        'Courgette trompette' => ['category' => 'Légumes', 'unit' => MeasurementUnit::GRAM, 'barcode' => '2306375001603'],
+        'Vin blanc sec' => ['category' => 'Boissons', 'unit' => MeasurementUnit::LITRE, 'barcode' => '3660989151932'],
+        'Échalotes' => ['category' => 'Légumes', 'unit' => MeasurementUnit::GRAM, 'barcode' => '8431876150353'],
+        'Persil' => ['category' => 'Herbes aromatiques', 'unit' => MeasurementUnit::GRAM, 'barcode' => '2006050101283'],
+        'Sole' => ['category' => 'Poissons', 'unit' => MeasurementUnit::UNIT, 'barcode' => '0059749982474'],
+        'Jus de citron' => ['category' => 'Épicerie', 'unit' => MeasurementUnit::LITRE, 'barcode' => '3564700299043'],
+        'Artichauts frais' => ['category' => 'Légumes', 'unit' => MeasurementUnit::UNIT, 'barcode' => '3256220652766'],
+        'Ail' => ['category' => 'Légumes', 'unit' => MeasurementUnit::UNIT, 'barcode' => '3256228100191'],
+        'Sucre glace' => ['category' => 'Épicerie', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3220035730001'],
+        'Gousse de vanille' => ['category' => 'Épices', 'unit' => MeasurementUnit::UNIT, 'barcode' => '3256225732043'],
+        'Jaunes d’œuf' => ['category' => 'Œufs', 'unit' => MeasurementUnit::UNIT, 'barcode' => '3439496001838'],
+        'Fécule' => ['category' => 'Farines', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3347431805482'],
+        'Pêches' => ['category' => 'Fruits', 'unit' => MeasurementUnit::UNIT, 'barcode' => '3276559409466'],
+        'Sirop' => ['category' => 'Épicerie', 'unit' => MeasurementUnit::LITRE, 'barcode' => '5708776000877'],
+        'Vanille' => ['category' => 'Épices', 'unit' => MeasurementUnit::GRAM, 'barcode' => '6133798001790'],
+        'Framboises' => ['category' => 'Fruits', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3385630118309'],
+        'Glace vanille' => ['category' => 'Desserts', 'unit' => MeasurementUnit::GRAM, 'barcode' => '26048154'],
+        'Sélection de fromages de vache, chèvre, brebis' => ['category' => 'Fromages', 'unit' => MeasurementUnit::GRAM, 'barcode' => '0200340018370'],
+    ];
+
+    private ImageService $images;
+
+    private OpenFoodFactsService $openFoodFacts;
+
+    /** @var array<int, string> */
+    private array $missingIngredients = [];
+
+    /** @var array<int, string> */
+    private array $missingComponents = [];
+
+    /** @var array<int, string> */
+    private array $missingImages = [];
+
+    /** @var array<string, ?string> */
+    private array $productImages = [];
+
+    public function __construct(ImageService $images, OpenFoodFactsService $openFoodFacts)
+    {
+        $this->images = $images;
+        $this->openFoodFacts = $openFoodFacts;
+    }
+
+    public function run(): void
+    {
+        $company = Company::updateOrCreate(
+            ['name' => self::COMPANY_PROFILE['name']],
+            ['open_food_facts_language' => self::COMPANY_PROFILE['open_food_facts_language']]
+        );
+
+        $this->seedUsers($company);
+
+        $defaultLocation = $this->resolveDefaultLocation($company);
+        $categoryIds = $this->ensureCategories($company);
+        $ingredients = $this->seedIngredients($company, $categoryIds, $defaultLocation);
+        $preparationCategoryId = $categoryIds['Préparations Maison'] ?? (int) reset($categoryIds);
+        $preparations = $this->seedPreparations(
+            $company,
+            $preparationCategoryId,
+            $defaultLocation,
+            $ingredients
+        );
+        $menuCategories = $this->ensureMenuCategories($company);
+        $this->seedMenus(
+            $company,
+            self::MENU_SECTIONS,
+            $menuCategories,
+            $ingredients,
+            $preparations,
+            $defaultLocation
+        );
+
+        $this->report();
+    }
+
+    private function seedUsers(Company $company): void
+    {
+        foreach (self::COMPANY_PROFILE['users'] as $userData) {
+            User::updateOrCreate(
+                ['email' => $userData['email']],
+                [
+                    'name' => $userData['name'],
+                    'company_id' => $company->id,
+                    'password' => 'password',
+                ]
+            );
+        }
+    }
+
+    private function resolveDefaultLocation(Company $company): Location
+    {
+        $desiredName = 'Chambre froide Maison Gustave';
+
+        $location = $company->locations()->firstWhere('name', $desiredName);
+        if ($location instanceof Location) {
+            return $location;
+        }
+
+        $existing = $company->locations()->firstWhere('name', 'Réfrigérateur');
+        if ($existing instanceof Location) {
+            $existing->update(['name' => $desiredName]);
+
+            return $existing->refresh();
+        }
+
+        $type = $company->locationTypes()->firstWhere('name', 'Réfrigérateur')
+            ?? $company->locationTypes()->first();
+
+        return $company->locations()->create([
+            'name' => $desiredName,
+            'location_type_id' => $type?->id,
+        ]);
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function ensureCategories(Company $company): array
+    {
+        $names = array_map(
+            fn (array $meta) => $meta['category'] ?? 'Ingrédients Divers',
+            self::INGREDIENTS
+        );
+        $names[] = 'Préparations Maison';
+        $names[] = 'Ingrédients Divers';
+        $names = array_values(array_unique($names));
+
+        $categories = [];
+        foreach ($names as $name) {
+            $category = Category::updateOrCreate(
+                [
+                    'company_id' => $company->id,
+                    'name' => $name,
+                ],
+                []
+            );
+
+            $categories[$name] = $category->id;
+        }
+
+        return $categories;
+    }
+
+    /**
+     * @return array<string, Ingredient>
+     */
+    private function seedIngredients(Company $company, array $categoryIds, Location $defaultLocation): array
+    {
+        $ingredients = [];
+        $fallbackCategoryId = $categoryIds['Ingrédients Divers'] ?? (int) reset($categoryIds);
+
+        foreach (self::INGREDIENTS as $name => $meta) {
+            $categoryId = $categoryIds[$meta['category']] ?? $fallbackCategoryId;
+
+            $ingredient = Ingredient::updateOrCreate(
+                [
+                    'company_id' => $company->id,
+                    'name' => $name,
+                ],
+                [
+                    'category_id' => $categoryId,
+                    'unit' => $meta['unit']->value,
+                    'base_quantity' => 0,
+                    'base_unit' => $meta['unit']->value,
+                    'barcode' => $meta['barcode'] ?? null,
+                ]
+            );
+
+            if (empty($ingredient->image_url) && ! empty($meta['barcode'])) {
+                $imagePath = $this->storeImageFromOpenFoodFacts($name, $meta['barcode']);
+                if ($imagePath) {
+                    $ingredient->update(['image_url' => $imagePath]);
+                }
+            }
+
+            $ingredient->locations()->syncWithoutDetaching([
+                $defaultLocation->id => ['quantity' => 0],
+            ]);
+
+            $ingredients[$name] = $ingredient;
+        }
+
+        return $ingredients;
+    }
+
+    private function storeImageFromOpenFoodFacts(string $ingredientName, string $barcode): ?string
+    {
+        if (isset($this->productImages[$barcode])) {
+            return $this->productImages[$barcode];
+        }
+
+        try {
+            $data = $this->openFoodFacts->searchByBarcode($barcode);
+        } catch (Throwable $exception) {
+            $this->missingImages[] = $ingredientName.' (erreur API)';
+
+            return $this->productImages[$barcode] = null;
+        }
+
+        if (! is_array($data)) {
+            $this->missingImages[] = $ingredientName.' (produit introuvable)';
+
+            return $this->productImages[$barcode] = null;
+        }
+
+        $product = $data['product'] ?? $data;
+        $imageUrl = null;
+
+        if (is_array($product)) {
+            $imageUrl = $product['image_front_url']
+                ?? $product['image_url']
+                ?? null;
+        }
+
+        if (! is_string($imageUrl) || ! filter_var($imageUrl, FILTER_VALIDATE_URL)) {
+            $this->missingImages[] = $ingredientName.' (image manquante)';
+
+            return $this->productImages[$barcode] = null;
+        }
+
+        try {
+            $stored = $this->images->storeFromUrl($imageUrl, 'ingredients');
+        } catch (Throwable $exception) {
+            $this->missingImages[] = $ingredientName.' (téléchargement)';
+
+            return $this->productImages[$barcode] = null;
+        }
+
+        return $this->productImages[$barcode] = $stored;
+    }
+
+    /**
+     * @param  array<string, Ingredient>  $ingredients
+     * @return array<string, Preparation>
+     */
+    private function seedPreparations(
+        Company $company,
+        int $categoryId,
+        Location $defaultLocation,
+        array $ingredients
+    ): array {
+        $cache = [];
+
+        foreach (array_keys(self::PREPARATION_COMPONENTS) as $name) {
+            $this->buildPreparation(
+                $name,
+                $company,
+                $categoryId,
+                $defaultLocation,
+                $ingredients,
+                $cache
+            );
+        }
+
+        return $cache;
+    }
+
+    /**
+     * @param  array<string, Ingredient>  $ingredients
+     * @param  array<string, Preparation>  $cache
+     */
+    private function buildPreparation(
+        string $name,
+        Company $company,
+        int $categoryId,
+        Location $defaultLocation,
+        array $ingredients,
+        array &$cache
+    ): ?Preparation {
+        if (isset($cache[$name])) {
+            return $cache[$name];
+        }
+
+        $definition = self::PREPARATION_COMPONENTS[$name] ?? null;
+        if (! $definition) {
+            return null;
+        }
+
+        $imagePath = null;
+        try {
+            $imagePath = $this->images->storePlaceholder();
+        } catch (Throwable $exception) {
+            $imagePath = null;
+        }
+
+        $preparation = Preparation::updateOrCreate(
+            [
+                'company_id' => $company->id,
+                'name' => $name,
+            ],
+            [
+                'category_id' => $categoryId,
+                'image_url' => $imagePath,
+                'unit' => MeasurementUnit::UNIT->value,
+                'base_quantity' => 0,
+                'base_unit' => MeasurementUnit::UNIT->value,
+            ]
+        );
+
+        $preparation->locations()->syncWithoutDetaching([
+            $defaultLocation->id => ['quantity' => 0],
+        ]);
+
+        $preparation->entities()->delete();
+
+        foreach ($definition as $component) {
+            if (isset($component['ingredient'])) {
+                $ingredientName = $component['ingredient'];
+                $ingredient = $ingredients[$ingredientName] ?? null;
+                if (! $ingredient) {
+                    $this->missingIngredients[] = $ingredientName.' (préparation '.$name.')';
+
+                    continue;
+                }
+
+                $preparation->entities()->create([
+                    'entity_id' => $ingredient->id,
+                    'entity_type' => Ingredient::class,
+                    'location_id' => $defaultLocation->id,
+                    'quantity' => 0,
+                    'unit' => $ingredient->unit->value,
+                ]);
+
+                continue;
+            }
+
+            if (isset($component['preparation'])) {
+                $childName = $component['preparation'];
+                $child = $this->buildPreparation(
+                    $childName,
+                    $company,
+                    $categoryId,
+                    $defaultLocation,
+                    $ingredients,
+                    $cache
+                );
+
+                if (! $child) {
+                    $this->missingComponents[] = $childName.' (préparation '.$name.')';
+
+                    continue;
+                }
+
+                $preparation->entities()->create([
+                    'entity_id' => $child->id,
+                    'entity_type' => Preparation::class,
+                    'location_id' => $defaultLocation->id,
+                    'quantity' => 0,
+                    'unit' => MeasurementUnit::UNIT->value,
+                ]);
+            }
+        }
+
+        return $cache[$name] = $preparation;
+    }
+
+    /**
+     * @return array<string, MenuCategory>
+     */
+    private function ensureMenuCategories(Company $company): array
+    {
+        $result = [];
+
+        foreach (self::MENU_CATEGORY_LABELS as $key => $label) {
+            $result[$key] = MenuCategory::updateOrCreate(
+                [
+                    'company_id' => $company->id,
+                    'name' => $label,
+                ],
+                []
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param  array<string, MenuCategory>  $menuCategories
+     * @param  array<string, Ingredient>  $ingredients
+     * @param  array<string, Preparation>  $preparations
+     * @param  array<string, array<int, array{name: string, price: float, ingredients: array<int, string>, preparations: array<int, string>}>>  $dataset
+     */
+    private function seedMenus(
+        Company $company,
+        array $dataset,
+        array $menuCategories,
+        array $ingredients,
+        array $preparations,
+        Location $defaultLocation
+    ): void {
+        foreach ($dataset as $section => $entries) {
+            $menuCategory = $menuCategories[$section] ?? null;
+            $menuType = self::MENU_TYPE_MAP[$section] ?? 'plat';
+
+            foreach ($entries as $entry) {
+                $menu = Menu::updateOrCreate(
+                    [
+                        'company_id' => $company->id,
+                        'name' => $entry['name'],
+                    ],
+                    [
+                        'description' => null,
+                        'image_url' => null,
+                        'is_a_la_carte' => true,
+                        'type' => $menuType,
+                        'price' => $entry['price'],
+                    ]
+                );
+
+                if ($menuCategory instanceof MenuCategory) {
+                    $menu->categories()->syncWithoutDetaching([$menuCategory->id]);
+                }
+
+                foreach ($entry['ingredients'] as $ingredientName) {
+                    $ingredient = $ingredients[$ingredientName] ?? null;
+                    if (! $ingredient) {
+                        $this->missingComponents[] = $ingredientName.' (menu '.$entry['name'].')';
+
+                        continue;
+                    }
+
+                    $locationId = $ingredient->locations()->first()?->id ?? $defaultLocation->id;
+
+                    MenuItem::updateOrCreate(
+                        [
+                            'menu_id' => $menu->id,
+                            'entity_id' => $ingredient->id,
+                            'entity_type' => Ingredient::class,
+                        ],
+                        [
+                            'location_id' => $locationId,
+                            'quantity' => 0,
+                            'unit' => $ingredient->unit->value,
+                        ]
+                    );
+                }
+
+                foreach ($entry['preparations'] as $preparationName) {
+                    $preparation = $preparations[$preparationName] ?? null;
+                    if (! $preparation) {
+                        $this->missingComponents[] = $preparationName.' (menu '.$entry['name'].')';
+
+                        continue;
+                    }
+
+                    $locationId = $preparation->locations()->first()?->id ?? $defaultLocation->id;
+
+                    MenuItem::updateOrCreate(
+                        [
+                            'menu_id' => $menu->id,
+                            'entity_id' => $preparation->id,
+                            'entity_type' => Preparation::class,
+                        ],
+                        [
+                            'location_id' => $locationId,
+                            'quantity' => 0,
+                            'unit' => MeasurementUnit::UNIT->value,
+                        ]
+                    );
+                }
+            }
+        }
+    }
+
+    private function report(): void
+    {
+        if (! empty($this->missingIngredients)) {
+            $this->command?->warn('Ingrédients manquants : '.implode(', ', array_unique($this->missingIngredients)));
+        }
+
+        if (! empty($this->missingComponents)) {
+            $this->command?->warn('Références indisponibles : '.implode(', ', array_unique($this->missingComponents)));
+        }
+
+        if (! empty($this->missingImages)) {
+            $this->command?->warn('Images non récupérées : '.implode(', ', array_unique($this->missingImages)));
+        }
+    }
+}

--- a/database/seeders/DemoSeeder.php
+++ b/database/seeders/DemoSeeder.php
@@ -825,7 +825,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 500,
-            'stock' => 10,
+            'stock' => 0,
             'barcode' => '26078410',
         ],
         'Lait' => [
@@ -849,7 +849,7 @@ class DemoSeeder extends Seeder
             'unit' => MeasurementUnit::UNIT,
             'base_unit' => MeasurementUnit::GRAM,
             'base_quantity' => 600,
-            'stock' => 12,
+            'stock' => 0,
             'barcode' => '3770000648317',
         ],
         'Haricots verts frais' => [
@@ -1148,7 +1148,7 @@ class DemoSeeder extends Seeder
         'Pickles de légumes' => 30,
         'Brioche parisienne' => 36,
         'Jus de marinière' => 40,
-        'Sole à la meunière' => 16,
+        'Sole à la meunière' => 0,
         'Cassolette d’artichauts' => 18,
         'Millefeuille' => 30,
         'Pêches pochées' => 24,

--- a/database/seeders/DemoSeeder.php
+++ b/database/seeders/DemoSeeder.php
@@ -127,164 +127,813 @@ class DemoSeeder extends Seeder
 
     private const PREPARATION_COMPONENTS = [
         'Pâte brisée' => [
-            ['ingredient' => 'Farine'],
-            ['ingredient' => 'Beurre'],
-            ['ingredient' => 'Eau'],
-            ['ingredient' => 'Sel'],
+            [
+                'ingredient' => 'Farine',
+                'quantity' => 500,
+                'unit' => MeasurementUnit::GRAM,
+            ],
+            [
+                'ingredient' => 'Beurre',
+                'quantity' => 250,
+                'unit' => MeasurementUnit::GRAM,
+            ],
+            [
+                'ingredient' => 'Eau',
+                'quantity' => 120,
+                'unit' => MeasurementUnit::MILLILITRE,
+            ],
+            [
+                'ingredient' => 'Sel',
+                'quantity' => 10,
+                'unit' => MeasurementUnit::GRAM,
+            ],
         ],
         'Farce de porc maison' => [
-            ['ingredient' => 'Échine de porc'],
-            ['ingredient' => 'Veau'],
-            ['ingredient' => 'Foie de volaille'],
-            ['ingredient' => 'Œufs'],
-            ['ingredient' => 'Crème'],
-            ['ingredient' => 'Sel'],
-            ['ingredient' => 'Poivre'],
-            ['ingredient' => 'Armagnac'],
-            ['ingredient' => 'Épices'],
+            [
+                'ingredient' => 'Échine de porc',
+                'quantity' => 4,
+                'unit' => MeasurementUnit::UNIT,
+            ],
+            [
+                'ingredient' => 'Veau',
+                'quantity' => 3,
+                'unit' => MeasurementUnit::UNIT,
+            ],
+            [
+                'ingredient' => 'Foie de volaille',
+                'quantity' => 4,
+                'unit' => MeasurementUnit::UNIT,
+            ],
+            [
+                'ingredient' => 'Œufs',
+                'quantity' => 2,
+                'unit' => MeasurementUnit::UNIT,
+            ],
+            [
+                'ingredient' => 'Crème',
+                'quantity' => 200,
+                'unit' => MeasurementUnit::MILLILITRE,
+            ],
+            [
+                'ingredient' => 'Sel',
+                'quantity' => 12,
+                'unit' => MeasurementUnit::GRAM,
+            ],
+            [
+                'ingredient' => 'Poivre',
+                'quantity' => 6,
+                'unit' => MeasurementUnit::GRAM,
+            ],
+            [
+                'ingredient' => 'Armagnac',
+                'quantity' => 30,
+                'unit' => MeasurementUnit::MILLILITRE,
+            ],
+            [
+                'ingredient' => 'Épices',
+                'quantity' => 5,
+                'unit' => MeasurementUnit::GRAM,
+            ],
         ],
         'Gelée' => [
-            ['ingredient' => 'Fond de volaille'],
-            ['ingredient' => 'Gélatine'],
+            [
+                'ingredient' => 'Fond de volaille',
+                'quantity' => 600,
+                'unit' => MeasurementUnit::MILLILITRE,
+            ],
+            [
+                'ingredient' => 'Gélatine',
+                'quantity' => 20,
+                'unit' => MeasurementUnit::GRAM,
+            ],
         ],
         'Pâté en croûte' => [
-            ['preparation' => 'Pâte brisée'],
-            ['preparation' => 'Farce de porc maison'],
-            ['preparation' => 'Gelée'],
+            [
+                'preparation' => 'Pâte brisée',
+                'quantity' => 1,
+                'unit' => MeasurementUnit::UNIT,
+            ],
+            [
+                'preparation' => 'Farce de porc maison',
+                'quantity' => 1,
+                'unit' => MeasurementUnit::UNIT,
+            ],
+            [
+                'preparation' => 'Gelée',
+                'quantity' => 1,
+                'unit' => MeasurementUnit::UNIT,
+            ],
         ],
         'Marinade' => [
-            ['ingredient' => 'Vinaigre blanc'],
-            ['ingredient' => 'Eau'],
-            ['ingredient' => 'Sucre'],
-            ['ingredient' => 'Sel'],
-            ['ingredient' => 'Graines de moutarde'],
-            ['ingredient' => 'Poivre'],
+            [
+                'ingredient' => 'Vinaigre blanc',
+                'quantity' => 300,
+                'unit' => MeasurementUnit::MILLILITRE,
+            ],
+            [
+                'ingredient' => 'Eau',
+                'quantity' => 200,
+                'unit' => MeasurementUnit::MILLILITRE,
+            ],
+            [
+                'ingredient' => 'Sucre',
+                'quantity' => 80,
+                'unit' => MeasurementUnit::GRAM,
+            ],
+            [
+                'ingredient' => 'Sel',
+                'quantity' => 20,
+                'unit' => MeasurementUnit::GRAM,
+            ],
+            [
+                'ingredient' => 'Graines de moutarde',
+                'quantity' => 15,
+                'unit' => MeasurementUnit::GRAM,
+            ],
+            [
+                'ingredient' => 'Poivre',
+                'quantity' => 8,
+                'unit' => MeasurementUnit::GRAM,
+            ],
         ],
         'Pickles de légumes' => [
-            ['ingredient' => 'Carottes'],
-            ['ingredient' => 'Chou-fleur'],
-            ['ingredient' => 'Oignons'],
-            ['ingredient' => 'Cornichons'],
-            ['preparation' => 'Marinade'],
+            [
+                'ingredient' => 'Carottes',
+                'quantity' => 1.5,
+                'unit' => MeasurementUnit::KILOGRAM,
+            ],
+            [
+                'ingredient' => 'Chou-fleur',
+                'quantity' => 3,
+                'unit' => MeasurementUnit::UNIT,
+            ],
+            [
+                'ingredient' => 'Oignons',
+                'quantity' => 1,
+                'unit' => MeasurementUnit::KILOGRAM,
+            ],
+            [
+                'ingredient' => 'Cornichons',
+                'quantity' => 0.8,
+                'unit' => MeasurementUnit::KILOGRAM,
+            ],
+            [
+                'preparation' => 'Marinade',
+                'quantity' => 1,
+                'unit' => MeasurementUnit::UNIT,
+            ],
         ],
         'Brioche parisienne' => [
-            ['ingredient' => 'Farine'],
-            ['ingredient' => 'Œufs'],
-            ['ingredient' => 'Beurre'],
-            ['ingredient' => 'Lait'],
-            ['ingredient' => 'Sucre'],
-            ['ingredient' => 'Levure de boulanger'],
-            ['ingredient' => 'Sel'],
+            [
+                'ingredient' => 'Farine',
+                'quantity' => 1.2,
+                'unit' => MeasurementUnit::KILOGRAM,
+            ],
+            [
+                'ingredient' => 'Œufs',
+                'quantity' => 8,
+                'unit' => MeasurementUnit::UNIT,
+            ],
+            [
+                'ingredient' => 'Beurre',
+                'quantity' => 0.5,
+                'unit' => MeasurementUnit::KILOGRAM,
+            ],
+            [
+                'ingredient' => 'Lait',
+                'quantity' => 500,
+                'unit' => MeasurementUnit::MILLILITRE,
+            ],
+            [
+                'ingredient' => 'Sucre',
+                'quantity' => 0.2,
+                'unit' => MeasurementUnit::KILOGRAM,
+            ],
+            [
+                'ingredient' => 'Levure de boulanger',
+                'quantity' => 40,
+                'unit' => MeasurementUnit::GRAM,
+            ],
+            [
+                'ingredient' => 'Sel',
+                'quantity' => 15,
+                'unit' => MeasurementUnit::GRAM,
+            ],
         ],
         'Jus de marinière' => [
-            ['ingredient' => 'Vin blanc sec'],
-            ['ingredient' => 'Échalotes'],
-            ['ingredient' => 'Beurre'],
-            ['ingredient' => 'Persil'],
-            ['ingredient' => 'Sel'],
-            ['ingredient' => 'Poivre'],
+            [
+                'ingredient' => 'Vin blanc sec',
+                'quantity' => 0.6,
+                'unit' => MeasurementUnit::LITRE,
+            ],
+            [
+                'ingredient' => 'Échalotes',
+                'quantity' => 0.4,
+                'unit' => MeasurementUnit::KILOGRAM,
+            ],
+            [
+                'ingredient' => 'Beurre',
+                'quantity' => 0.2,
+                'unit' => MeasurementUnit::KILOGRAM,
+            ],
+            [
+                'ingredient' => 'Persil',
+                'quantity' => 80,
+                'unit' => MeasurementUnit::GRAM,
+            ],
+            [
+                'ingredient' => 'Sel',
+                'quantity' => 10,
+                'unit' => MeasurementUnit::GRAM,
+            ],
+            [
+                'ingredient' => 'Poivre',
+                'quantity' => 5,
+                'unit' => MeasurementUnit::GRAM,
+            ],
         ],
         'Sole à la meunière' => [
-            ['ingredient' => 'Sole'],
-            ['ingredient' => 'Beurre'],
-            ['ingredient' => 'Farine'],
-            ['ingredient' => 'Jus de citron'],
-            ['ingredient' => 'Persil'],
+            [
+                'ingredient' => 'Sole',
+                'quantity' => 2,
+                'unit' => MeasurementUnit::UNIT,
+            ],
+            [
+                'ingredient' => 'Beurre',
+                'quantity' => 0.18,
+                'unit' => MeasurementUnit::KILOGRAM,
+            ],
+            [
+                'ingredient' => 'Farine',
+                'quantity' => 0.25,
+                'unit' => MeasurementUnit::KILOGRAM,
+            ],
+            [
+                'ingredient' => 'Jus de citron',
+                'quantity' => 120,
+                'unit' => MeasurementUnit::MILLILITRE,
+            ],
+            [
+                'ingredient' => 'Persil',
+                'quantity' => 60,
+                'unit' => MeasurementUnit::GRAM,
+            ],
         ],
         'Cassolette d’artichauts' => [
-            ['ingredient' => 'Artichauts frais'],
-            ['ingredient' => 'Fond de volaille'],
-            ['ingredient' => 'Huile d’olive'],
-            ['ingredient' => 'Ail'],
-            ['ingredient' => 'Sel'],
-            ['ingredient' => 'Poivre'],
+            [
+                'ingredient' => 'Artichauts frais',
+                'quantity' => 4,
+                'unit' => MeasurementUnit::UNIT,
+            ],
+            [
+                'ingredient' => 'Fond de volaille',
+                'quantity' => 800,
+                'unit' => MeasurementUnit::MILLILITRE,
+            ],
+            [
+                'ingredient' => 'Huile d’olive',
+                'quantity' => 120,
+                'unit' => MeasurementUnit::MILLILITRE,
+            ],
+            [
+                'ingredient' => 'Ail',
+                'quantity' => 6,
+                'unit' => MeasurementUnit::UNIT,
+            ],
+            [
+                'ingredient' => 'Sel',
+                'quantity' => 8,
+                'unit' => MeasurementUnit::GRAM,
+            ],
+            [
+                'ingredient' => 'Poivre',
+                'quantity' => 4,
+                'unit' => MeasurementUnit::GRAM,
+            ],
         ],
         'Pâte feuilletée' => [
-            ['ingredient' => 'Farine'],
-            ['ingredient' => 'Beurre'],
-            ['ingredient' => 'Eau'],
-            ['ingredient' => 'Sel'],
+            [
+                'ingredient' => 'Farine',
+                'quantity' => 1.5,
+                'unit' => MeasurementUnit::KILOGRAM,
+            ],
+            [
+                'ingredient' => 'Beurre',
+                'quantity' => 1,
+                'unit' => MeasurementUnit::KILOGRAM,
+            ],
+            [
+                'ingredient' => 'Eau',
+                'quantity' => 600,
+                'unit' => MeasurementUnit::MILLILITRE,
+            ],
+            [
+                'ingredient' => 'Sel',
+                'quantity' => 15,
+                'unit' => MeasurementUnit::GRAM,
+            ],
         ],
         'Crème pâtissière à la vanille' => [
-            ['ingredient' => 'Lait'],
-            ['ingredient' => 'Sucre'],
-            ['ingredient' => 'Jaunes d’œuf'],
-            ['ingredient' => 'Fécule'],
-            ['ingredient' => 'Gousse de vanille'],
+            [
+                'ingredient' => 'Lait',
+                'quantity' => 2000,
+                'unit' => MeasurementUnit::MILLILITRE,
+            ],
+            [
+                'ingredient' => 'Sucre',
+                'quantity' => 0.35,
+                'unit' => MeasurementUnit::KILOGRAM,
+            ],
+            [
+                'ingredient' => 'Jaunes d’œuf',
+                'quantity' => 18,
+                'unit' => MeasurementUnit::UNIT,
+            ],
+            [
+                'ingredient' => 'Fécule',
+                'quantity' => 0.12,
+                'unit' => MeasurementUnit::KILOGRAM,
+            ],
+            [
+                'ingredient' => 'Gousse de vanille',
+                'quantity' => 6,
+                'unit' => MeasurementUnit::UNIT,
+            ],
         ],
         'Millefeuille' => [
-            ['preparation' => 'Pâte feuilletée'],
-            ['preparation' => 'Crème pâtissière à la vanille'],
-            ['ingredient' => 'Sucre glace'],
+            [
+                'preparation' => 'Pâte feuilletée',
+                'quantity' => 1,
+                'unit' => MeasurementUnit::UNIT,
+            ],
+            [
+                'preparation' => 'Crème pâtissière à la vanille',
+                'quantity' => 1,
+                'unit' => MeasurementUnit::UNIT,
+            ],
+            [
+                'ingredient' => 'Sucre glace',
+                'quantity' => 0.25,
+                'unit' => MeasurementUnit::KILOGRAM,
+            ],
         ],
         'Pêches pochées' => [
-            ['ingredient' => 'Pêches'],
-            ['ingredient' => 'Sirop'],
-            ['ingredient' => 'Vanille'],
+            [
+                'ingredient' => 'Pêches',
+                'quantity' => 12,
+                'unit' => MeasurementUnit::UNIT,
+            ],
+            [
+                'ingredient' => 'Sirop',
+                'quantity' => 1500,
+                'unit' => MeasurementUnit::MILLILITRE,
+            ],
+            [
+                'ingredient' => 'Vanille',
+                'quantity' => 25,
+                'unit' => MeasurementUnit::GRAM,
+            ],
         ],
         'Coulis de framboise' => [
-            ['ingredient' => 'Framboises'],
-            ['ingredient' => 'Sucre'],
+            [
+                'ingredient' => 'Framboises',
+                'quantity' => 1.2,
+                'unit' => MeasurementUnit::KILOGRAM,
+            ],
+            [
+                'ingredient' => 'Sucre',
+                'quantity' => 0.3,
+                'unit' => MeasurementUnit::KILOGRAM,
+            ],
         ],
         'Pêche Melba' => [
-            ['preparation' => 'Pêches pochées'],
-            ['preparation' => 'Coulis de framboise'],
-            ['ingredient' => 'Glace vanille'],
+            [
+                'preparation' => 'Pêches pochées',
+                'quantity' => 1,
+                'unit' => MeasurementUnit::UNIT,
+            ],
+            [
+                'preparation' => 'Coulis de framboise',
+                'quantity' => 1,
+                'unit' => MeasurementUnit::UNIT,
+            ],
+            [
+                'ingredient' => 'Glace vanille',
+                'quantity' => 1.5,
+                'unit' => MeasurementUnit::LITRE,
+            ],
         ],
     ];
 
     private const INGREDIENTS = [
-        'Farine' => ['category' => 'Farines', 'unit' => MeasurementUnit::GRAM, 'barcode' => '4056489565536'],
-        'Beurre' => ['category' => 'Produits Laitiers', 'unit' => MeasurementUnit::GRAM, 'barcode' => '26064413'],
-        'Eau' => ['category' => 'Boissons', 'unit' => MeasurementUnit::LITRE, 'barcode' => '1234500001857'],
-        'Sel' => ['category' => 'Épicerie', 'unit' => MeasurementUnit::GRAM, 'barcode' => '10020811'],
-        'Échine de porc' => ['category' => 'Viandes', 'unit' => MeasurementUnit::GRAM, 'barcode' => '0207024022173'],
-        'Veau' => ['category' => 'Viandes', 'unit' => MeasurementUnit::GRAM, 'barcode' => '2695314012009'],
-        'Foie de volaille' => ['category' => 'Viandes', 'unit' => MeasurementUnit::GRAM, 'barcode' => '0215085018561'],
-        'Œufs' => ['category' => 'Œufs', 'unit' => MeasurementUnit::UNIT, 'barcode' => '3560070432080'],
-        'Crème' => ['category' => 'Produits Laitiers', 'unit' => MeasurementUnit::LITRE, 'barcode' => '3258561419299'],
-        'Poivre' => ['category' => 'Épices', 'unit' => MeasurementUnit::GRAM, 'barcode' => '8720254531779'],
-        'Armagnac' => ['category' => 'Spiritueux', 'unit' => MeasurementUnit::LITRE, 'barcode' => '3560070575480'],
-        'Épices' => ['category' => 'Épices', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3700483800544'],
-        'Fond de volaille' => ['category' => 'Épicerie', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3256225451647'],
-        'Gélatine' => ['category' => 'Épicerie', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3256225731978'],
-        'Carottes' => ['category' => 'Légumes', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3596710431151'],
-        'Chou-fleur' => ['category' => 'Légumes', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3560070122349'],
-        'Oignons' => ['category' => 'Légumes', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3363290420116'],
-        'Cornichons' => ['category' => 'Épicerie', 'unit' => MeasurementUnit::GRAM, 'barcode' => '4061464817722'],
-        'Vinaigre blanc' => ['category' => 'Épicerie', 'unit' => MeasurementUnit::LITRE, 'barcode' => '3077311522405'],
-        'Sucre' => ['category' => 'Épicerie', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3596710473557'],
-        'Graines de moutarde' => ['category' => 'Épices', 'unit' => MeasurementUnit::GRAM, 'barcode' => '7610845400434'],
-        'Foie gras de canard cru' => ['category' => 'Viandes', 'unit' => MeasurementUnit::GRAM, 'barcode' => '26078410'],
-        'Lait' => ['category' => 'Produits Laitiers', 'unit' => MeasurementUnit::LITRE, 'barcode' => '3428272970017'],
-        'Levure de boulanger' => ['category' => 'Épicerie', 'unit' => MeasurementUnit::GRAM, 'barcode' => '2006050036622'],
-        'Homard bleu' => ['category' => 'Fruits de Mer', 'unit' => MeasurementUnit::UNIT, 'barcode' => '3770000648317'],
-        'Haricots verts frais' => ['category' => 'Légumes', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3760086270076'],
-        'Amandes fraîches' => ['category' => 'Fruits secs', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3700194630287'],
-        'Huile d’olive' => ['category' => 'Épicerie', 'unit' => MeasurementUnit::LITRE, 'barcode' => '3424096003078'],
-        'Citron' => ['category' => 'Fruits', 'unit' => MeasurementUnit::UNIT, 'barcode' => '3256226081881'],
-        'Tomate de plein champ' => ['category' => 'Légumes', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3017800246658'],
-        'Filets d’anchois' => ['category' => 'Poissons', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3218370591821'],
-        'Basilic frais' => ['category' => 'Herbes aromatiques', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3411061111029'],
-        'Dos de bar' => ['category' => 'Poissons', 'unit' => MeasurementUnit::UNIT, 'barcode' => '3664335055264'],
-        'Courgette trompette' => ['category' => 'Légumes', 'unit' => MeasurementUnit::GRAM, 'barcode' => '2306375001603'],
-        'Vin blanc sec' => ['category' => 'Boissons', 'unit' => MeasurementUnit::LITRE, 'barcode' => '3660989151932'],
-        'Échalotes' => ['category' => 'Légumes', 'unit' => MeasurementUnit::GRAM, 'barcode' => '8431876150353'],
-        'Persil' => ['category' => 'Herbes aromatiques', 'unit' => MeasurementUnit::GRAM, 'barcode' => '2006050101283'],
-        'Sole' => ['category' => 'Poissons', 'unit' => MeasurementUnit::UNIT, 'barcode' => '0059749982474'],
-        'Jus de citron' => ['category' => 'Épicerie', 'unit' => MeasurementUnit::LITRE, 'barcode' => '3564700299043'],
-        'Artichauts frais' => ['category' => 'Légumes', 'unit' => MeasurementUnit::UNIT, 'barcode' => '3256220652766'],
-        'Ail' => ['category' => 'Légumes', 'unit' => MeasurementUnit::UNIT, 'barcode' => '3256228100191'],
-        'Sucre glace' => ['category' => 'Épicerie', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3220035730001'],
-        'Gousse de vanille' => ['category' => 'Épices', 'unit' => MeasurementUnit::UNIT, 'barcode' => '3256225732043'],
-        'Jaunes d’œuf' => ['category' => 'Œufs', 'unit' => MeasurementUnit::UNIT, 'barcode' => '3439496001838'],
-        'Fécule' => ['category' => 'Farines', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3347431805482'],
-        'Pêches' => ['category' => 'Fruits', 'unit' => MeasurementUnit::UNIT, 'barcode' => '3276559409466'],
-        'Sirop' => ['category' => 'Épicerie', 'unit' => MeasurementUnit::LITRE, 'barcode' => '5708776000877'],
-        'Vanille' => ['category' => 'Épices', 'unit' => MeasurementUnit::GRAM, 'barcode' => '6133798001790'],
-        'Framboises' => ['category' => 'Fruits', 'unit' => MeasurementUnit::GRAM, 'barcode' => '3385630118309'],
-        'Glace vanille' => ['category' => 'Desserts', 'unit' => MeasurementUnit::GRAM, 'barcode' => '26048154'],
-        'Sélection de fromages de vache, chèvre, brebis' => ['category' => 'Fromages', 'unit' => MeasurementUnit::GRAM, 'barcode' => '0200340018370'],
+        'Farine' => [
+            'category' => 'Farines',
+            'unit' => MeasurementUnit::GRAM,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 1000,
+            'stock' => 5000,
+            'barcode' => '4056489565536',
+        ],
+        'Beurre' => [
+            'category' => 'Produits Laitiers',
+            'unit' => MeasurementUnit::GRAM,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 250,
+            'stock' => 1500,
+            'barcode' => '26064413',
+        ],
+        'Eau' => [
+            'category' => 'Boissons',
+            'unit' => MeasurementUnit::LITRE,
+            'base_unit' => MeasurementUnit::MILLILITRE,
+            'base_quantity' => 1000,
+            'stock' => 50,
+            'barcode' => '1234500001857',
+        ],
+        'Sel' => [
+            'category' => 'Épicerie',
+            'unit' => MeasurementUnit::GRAM,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 1000,
+            'stock' => 2000,
+            'barcode' => '10020811',
+        ],
+        'Échine de porc' => [
+            'category' => 'Viandes',
+            'unit' => MeasurementUnit::UNIT,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 180,
+            'stock' => 24,
+            'barcode' => '0207024022173',
+        ],
+        'Veau' => [
+            'category' => 'Viandes',
+            'unit' => MeasurementUnit::UNIT,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 160,
+            'stock' => 18,
+            'barcode' => '2695314012009',
+        ],
+        'Foie de volaille' => [
+            'category' => 'Viandes',
+            'unit' => MeasurementUnit::UNIT,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 90,
+            'stock' => 40,
+            'barcode' => '0215085018561',
+        ],
+        'Œufs' => [
+            'category' => 'Œufs',
+            'unit' => MeasurementUnit::UNIT,
+            'base_unit' => MeasurementUnit::UNIT,
+            'base_quantity' => 1,
+            'stock' => 180,
+            'barcode' => '3560070432080',
+        ],
+        'Crème' => [
+            'category' => 'Produits Laitiers',
+            'unit' => MeasurementUnit::LITRE,
+            'base_unit' => MeasurementUnit::MILLILITRE,
+            'base_quantity' => 1000,
+            'stock' => 18,
+            'barcode' => '3258561419299',
+        ],
+        'Poivre' => [
+            'category' => 'Épices',
+            'unit' => MeasurementUnit::GRAM,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 250,
+            'stock' => 600,
+            'barcode' => '8720254531779',
+        ],
+        'Armagnac' => [
+            'category' => 'Spiritueux',
+            'unit' => MeasurementUnit::LITRE,
+            'base_unit' => MeasurementUnit::MILLILITRE,
+            'base_quantity' => 700,
+            'stock' => 8,
+            'barcode' => '3560070575480',
+        ],
+        'Épices' => [
+            'category' => 'Épices',
+            'unit' => MeasurementUnit::GRAM,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 200,
+            'stock' => 400,
+            'barcode' => '3700483800544',
+        ],
+        'Fond de volaille' => [
+            'category' => 'Épicerie',
+            'unit' => MeasurementUnit::LITRE,
+            'base_unit' => MeasurementUnit::MILLILITRE,
+            'base_quantity' => 1000,
+            'stock' => 15,
+            'barcode' => '3256225451647',
+        ],
+        'Gélatine' => [
+            'category' => 'Épicerie',
+            'unit' => MeasurementUnit::GRAM,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 200,
+            'stock' => 300,
+            'barcode' => '3256225731978',
+        ],
+        'Carottes' => [
+            'category' => 'Légumes',
+            'unit' => MeasurementUnit::KILOGRAM,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 1000,
+            'stock' => 12,
+            'barcode' => '3596710431151',
+        ],
+        'Chou-fleur' => [
+            'category' => 'Légumes',
+            'unit' => MeasurementUnit::UNIT,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 900,
+            'stock' => 18,
+            'barcode' => '3560070122349',
+        ],
+        'Oignons' => [
+            'category' => 'Légumes',
+            'unit' => MeasurementUnit::KILOGRAM,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 1000,
+            'stock' => 10,
+            'barcode' => '3363290420116',
+        ],
+        'Cornichons' => [
+            'category' => 'Épicerie',
+            'unit' => MeasurementUnit::KILOGRAM,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 500,
+            'stock' => 6,
+            'barcode' => '4061464817722',
+        ],
+        'Vinaigre blanc' => [
+            'category' => 'Épicerie',
+            'unit' => MeasurementUnit::LITRE,
+            'base_unit' => MeasurementUnit::MILLILITRE,
+            'base_quantity' => 1000,
+            'stock' => 20,
+            'barcode' => '3077311522405',
+        ],
+        'Sucre' => [
+            'category' => 'Épicerie',
+            'unit' => MeasurementUnit::KILOGRAM,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 1000,
+            'stock' => 18,
+            'barcode' => '3596710473557',
+        ],
+        'Graines de moutarde' => [
+            'category' => 'Épices',
+            'unit' => MeasurementUnit::GRAM,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 200,
+            'stock' => 350,
+            'barcode' => '7610845400434',
+        ],
+        'Foie gras de canard cru' => [
+            'category' => 'Viandes',
+            'unit' => MeasurementUnit::UNIT,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 500,
+            'stock' => 10,
+            'barcode' => '26078410',
+        ],
+        'Lait' => [
+            'category' => 'Produits Laitiers',
+            'unit' => MeasurementUnit::LITRE,
+            'base_unit' => MeasurementUnit::MILLILITRE,
+            'base_quantity' => 1000,
+            'stock' => 30,
+            'barcode' => '3428272970017',
+        ],
+        'Levure de boulanger' => [
+            'category' => 'Épicerie',
+            'unit' => MeasurementUnit::GRAM,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 100,
+            'stock' => 150,
+            'barcode' => '2006050036622',
+        ],
+        'Homard bleu' => [
+            'category' => 'Fruits de Mer',
+            'unit' => MeasurementUnit::UNIT,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 600,
+            'stock' => 12,
+            'barcode' => '3770000648317',
+        ],
+        'Haricots verts frais' => [
+            'category' => 'Légumes',
+            'unit' => MeasurementUnit::KILOGRAM,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 1000,
+            'stock' => 14,
+            'barcode' => '3760086270076',
+        ],
+        'Amandes fraîches' => [
+            'category' => 'Fruits secs',
+            'unit' => MeasurementUnit::KILOGRAM,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 500,
+            'stock' => 8,
+            'barcode' => '3700194630287',
+        ],
+        'Huile d’olive' => [
+            'category' => 'Épicerie',
+            'unit' => MeasurementUnit::LITRE,
+            'base_unit' => MeasurementUnit::MILLILITRE,
+            'base_quantity' => 1000,
+            'stock' => 25,
+            'barcode' => '3424096003078',
+        ],
+        'Citron' => [
+            'category' => 'Fruits',
+            'unit' => MeasurementUnit::UNIT,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 120,
+            'stock' => 45,
+            'barcode' => '3256226081881',
+        ],
+        'Tomate de plein champ' => [
+            'category' => 'Légumes',
+            'unit' => MeasurementUnit::UNIT,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 220,
+            'stock' => 60,
+            'barcode' => '3017800246658',
+        ],
+        'Filets d’anchois' => [
+            'category' => 'Poissons',
+            'unit' => MeasurementUnit::GRAM,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 500,
+            'stock' => 750,
+            'barcode' => '3218370591821',
+        ],
+        'Basilic frais' => [
+            'category' => 'Herbes aromatiques',
+            'unit' => MeasurementUnit::GRAM,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 200,
+            'stock' => 300,
+            'barcode' => '3411061111029',
+        ],
+        'Dos de bar' => [
+            'category' => 'Poissons',
+            'unit' => MeasurementUnit::UNIT,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 280,
+            'stock' => 16,
+            'barcode' => '3664335055264',
+        ],
+        'Courgette trompette' => [
+            'category' => 'Légumes',
+            'unit' => MeasurementUnit::UNIT,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 200,
+            'stock' => 32,
+            'barcode' => '2306375001603',
+        ],
+        'Vin blanc sec' => [
+            'category' => 'Boissons',
+            'unit' => MeasurementUnit::LITRE,
+            'base_unit' => MeasurementUnit::MILLILITRE,
+            'base_quantity' => 750,
+            'stock' => 24,
+            'barcode' => '3660989151932',
+        ],
+        'Échalotes' => [
+            'category' => 'Légumes',
+            'unit' => MeasurementUnit::KILOGRAM,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 1000,
+            'stock' => 8,
+            'barcode' => '8431876150353',
+        ],
+        'Persil' => [
+            'category' => 'Herbes aromatiques',
+            'unit' => MeasurementUnit::GRAM,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 200,
+            'stock' => 300,
+            'barcode' => '2006050101283',
+        ],
+        'Sole' => [
+            'category' => 'Poissons',
+            'unit' => MeasurementUnit::UNIT,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 350,
+            'stock' => 10,
+            'barcode' => '0059749982474',
+        ],
+        'Jus de citron' => [
+            'category' => 'Épicerie',
+            'unit' => MeasurementUnit::LITRE,
+            'base_unit' => MeasurementUnit::MILLILITRE,
+            'base_quantity' => 1000,
+            'stock' => 12,
+            'barcode' => '3564700299043',
+        ],
+        'Artichauts frais' => [
+            'category' => 'Légumes',
+            'unit' => MeasurementUnit::UNIT,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 320,
+            'stock' => 24,
+            'barcode' => '3256220652766',
+        ],
+        'Ail' => [
+            'category' => 'Légumes',
+            'unit' => MeasurementUnit::UNIT,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 60,
+            'stock' => 50,
+            'barcode' => '3256228100191',
+        ],
+        'Sucre glace' => [
+            'category' => 'Épicerie',
+            'unit' => MeasurementUnit::KILOGRAM,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 1000,
+            'stock' => 6,
+            'barcode' => '3220035730001',
+        ],
+        'Gousse de vanille' => [
+            'category' => 'Épices',
+            'unit' => MeasurementUnit::UNIT,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 6,
+            'stock' => 80,
+            'barcode' => '3256225732043',
+        ],
+        'Jaunes d’œuf' => [
+            'category' => 'Œufs',
+            'unit' => MeasurementUnit::UNIT,
+            'base_unit' => MeasurementUnit::UNIT,
+            'base_quantity' => 1,
+            'stock' => 200,
+            'barcode' => '3439496001838',
+        ],
+        'Fécule' => [
+            'category' => 'Farines',
+            'unit' => MeasurementUnit::GRAM,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 500,
+            'stock' => 600,
+            'barcode' => '3347431805482',
+        ],
+        'Pêches' => [
+            'category' => 'Fruits',
+            'unit' => MeasurementUnit::UNIT,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 180,
+            'stock' => 40,
+            'barcode' => '3276559409466',
+        ],
+        'Sirop' => [
+            'category' => 'Épicerie',
+            'unit' => MeasurementUnit::LITRE,
+            'base_unit' => MeasurementUnit::MILLILITRE,
+            'base_quantity' => 1000,
+            'stock' => 18,
+            'barcode' => '5708776000877',
+        ],
+        'Vanille' => [
+            'category' => 'Épices',
+            'unit' => MeasurementUnit::GRAM,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 100,
+            'stock' => 250,
+            'barcode' => '6133798001790',
+        ],
+        'Framboises' => [
+            'category' => 'Fruits',
+            'unit' => MeasurementUnit::KILOGRAM,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 1000,
+            'stock' => 12,
+            'barcode' => '3385630118309',
+        ],
+        'Glace vanille' => [
+            'category' => 'Desserts',
+            'unit' => MeasurementUnit::LITRE,
+            'base_unit' => MeasurementUnit::MILLILITRE,
+            'base_quantity' => 1000,
+            'stock' => 14,
+            'barcode' => '26048154',
+        ],
+        'Sélection de fromages de vache, chèvre, brebis' => [
+            'category' => 'Fromages',
+            'unit' => MeasurementUnit::KILOGRAM,
+            'base_unit' => MeasurementUnit::GRAM,
+            'base_quantity' => 1500,
+            'stock' => 9,
+            'barcode' => '0200340018370',
+        ],
     ];
 
     private const TEMP_IMAGE_FOLDER = 'tmp/demo-seeder/ingredients';
@@ -437,6 +1086,17 @@ class DemoSeeder extends Seeder
         foreach (self::INGREDIENTS as $name => $meta) {
             $categoryId = $categoryIds[$meta['category']] ?? $fallbackCategoryId;
 
+            $unit = $meta['unit'] instanceof MeasurementUnit
+                ? $meta['unit']
+                : MeasurementUnit::from($meta['unit']);
+            $baseUnit = isset($meta['base_unit'])
+                ? ($meta['base_unit'] instanceof MeasurementUnit
+                    ? $meta['base_unit']
+                    : MeasurementUnit::from($meta['base_unit']))
+                : $unit;
+            $baseQuantity = isset($meta['base_quantity']) ? (float) $meta['base_quantity'] : 0.0;
+            $stockQuantity = isset($meta['stock']) ? (float) $meta['stock'] : $baseQuantity;
+
             $ingredient = Ingredient::updateOrCreate(
                 [
                     'company_id' => $company->id,
@@ -444,9 +1104,9 @@ class DemoSeeder extends Seeder
                 ],
                 [
                     'category_id' => $categoryId,
-                    'unit' => $meta['unit']->value,
-                    'base_quantity' => 0,
-                    'base_unit' => $meta['unit']->value,
+                    'unit' => $unit->value,
+                    'base_quantity' => $baseQuantity,
+                    'base_unit' => $baseUnit->value,
                     'barcode' => $meta['barcode'] ?? null,
                 ]
             );
@@ -463,7 +1123,7 @@ class DemoSeeder extends Seeder
             }
 
             $ingredient->locations()->syncWithoutDetaching([
-                $defaultLocation->id => ['quantity' => 0],
+                $defaultLocation->id => ['quantity' => $stockQuantity],
             ]);
 
             $ingredients[$name] = $ingredient;
@@ -618,13 +1278,13 @@ class DemoSeeder extends Seeder
                 'category_id' => $categoryId,
                 'image_url' => $imagePath,
                 'unit' => MeasurementUnit::UNIT->value,
-                'base_quantity' => 0,
+                'base_quantity' => 1,
                 'base_unit' => MeasurementUnit::UNIT->value,
             ]
         );
 
         $preparation->locations()->syncWithoutDetaching([
-            $defaultLocation->id => ['quantity' => 0],
+            $defaultLocation->id => ['quantity' => 1],
         ]);
 
         $preparation->entities()->delete();
@@ -639,12 +1299,18 @@ class DemoSeeder extends Seeder
                     continue;
                 }
 
+                $quantity = isset($component['quantity']) ? (float) $component['quantity'] : 0.0;
+                $componentUnit = $component['unit'] ?? $ingredient->unit ?? MeasurementUnit::UNIT;
+                $componentUnit = $componentUnit instanceof MeasurementUnit
+                    ? $componentUnit
+                    : MeasurementUnit::from($componentUnit);
+
                 $preparation->entities()->create([
                     'entity_id' => $ingredient->id,
                     'entity_type' => Ingredient::class,
                     'location_id' => $defaultLocation->id,
-                    'quantity' => 0,
-                    'unit' => $ingredient->unit->value,
+                    'quantity' => $quantity,
+                    'unit' => $componentUnit->value,
                 ]);
 
                 continue;
@@ -667,12 +1333,18 @@ class DemoSeeder extends Seeder
                     continue;
                 }
 
+                $quantity = isset($component['quantity']) ? (float) $component['quantity'] : 1.0;
+                $componentUnit = $component['unit'] ?? MeasurementUnit::UNIT;
+                $componentUnit = $componentUnit instanceof MeasurementUnit
+                    ? $componentUnit
+                    : MeasurementUnit::from($componentUnit);
+
                 $preparation->entities()->create([
                     'entity_id' => $child->id,
                     'entity_type' => Preparation::class,
                     'location_id' => $defaultLocation->id,
-                    'quantity' => 0,
-                    'unit' => MeasurementUnit::UNIT->value,
+                    'quantity' => $quantity,
+                    'unit' => $componentUnit->value,
                 ]);
             }
         }


### PR DESCRIPTION
## Summary
- rework the demo seeder into structured PHP arrays that create the Maison Gustave company, demo users, menu sections, ingredients and preparations
- call the OpenFoodFactsService to fetch ingredient images by barcode while keeping placeholder fallbacks and reporting for missing data
- add a `make demo-seed` shortcut that resets MinIO, runs a fresh migration, and then seeds only the DemoSeeder so the dataset loads on a clean base
- update the demo users to first-name Gmail accounts and keep the seeder optional by removing it from the default DatabaseSeeder chain
- normalize Makefile command indentation for consistent formatting

## Testing
- vendor/bin/pint
- vendor/bin/phpstan analyse --memory-limit=2G
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68c9e5e2dfb8832da5f97311b936ca92