### PR TITLE
Add pagination to menus GraphQL query

### DIFF
--- a/graphql/models/menu.graphql
+++ b/graphql/models/menu.graphql
@@ -36,6 +36,6 @@ extend type Query @guard {
         price_between: [Float!] @scope(name: "priceBetween")
         "Filtrer par disponibilité."
         available: Boolean @scope(name: "available")
-    ): [Menu!]! @all(scopes: ["forCompany"])
+    ): [Menu!]! @paginate(defaultCount: 10, scopes: ["forCompany"])
     menu(id: ID! @eq): Menu @find(scopes: ["forCompany"])
 }

--- a/tests/Feature/MenuAllergenQueryTest.php
+++ b/tests/Feature/MenuAllergenQueryTest.php
@@ -86,7 +86,9 @@ class MenuAllergenQueryTest extends TestCase
         $query = /* @lang GraphQL */ '
             query ($allergens: [AllergenEnum!]) {
                 menus(allergens: $allergens) {
-                    id
+                    data {
+                        id
+                    }
                 }
             }
         ';
@@ -95,7 +97,7 @@ class MenuAllergenQueryTest extends TestCase
             'allergens' => [Allergen::MILK->value, Allergen::GLUTEN->value],
         ]);
 
-        $response->assertJsonCount(3, 'data.menus');
+        $response->assertJsonCount(3, 'data.menus.data');
         $response->assertJsonFragment(['id' => (string) $menuMilk->id]);
         $response->assertJsonFragment(['id' => (string) $menuGluten->id]);
         $response->assertJsonFragment(['id' => (string) $menuBoth->id]);

--- a/tests/Feature/MenuAvailabilityQueryTest.php
+++ b/tests/Feature/MenuAvailabilityQueryTest.php
@@ -114,20 +114,22 @@ class MenuAvailabilityQueryTest extends TestCase
         $query = /** @lang GraphQL */ '
             query ($available: Boolean) {
                 menus(available: $available) {
-                    id
+                    data {
+                        id
+                    }
                 }
             }
         ';
 
         $this->actingAs($user)
             ->graphQL($query, ['available' => true])
-            ->assertJsonCount(1, 'data.menus')
+            ->assertJsonCount(1, 'data.menus.data')
             ->assertJsonFragment(['id' => (string) $menuAvailable->id])
             ->assertJsonMissing(['id' => (string) $menuUnavailable->id]);
 
         $this->actingAs($user)
             ->graphQL($query, ['available' => false])
-            ->assertJsonCount(1, 'data.menus')
+            ->assertJsonCount(1, 'data.menus.data')
             ->assertJsonFragment(['id' => (string) $menuUnavailable->id])
             ->assertJsonMissing(['id' => (string) $menuAvailable->id]);
     }

--- a/tests/Feature/MenuCategoryQueryTest.php
+++ b/tests/Feature/MenuCategoryQueryTest.php
@@ -37,7 +37,9 @@ class MenuCategoryQueryTest extends TestCase
         $query = /* @lang GraphQL */ '
             query ($category_ids: [ID!]) {
                 menus(category_ids: $category_ids) {
-                    id
+                    data {
+                        id
+                    }
                 }
             }
         ';
@@ -46,7 +48,7 @@ class MenuCategoryQueryTest extends TestCase
             'category_ids' => [$halal->id, $vegan->id],
         ]);
 
-        $response->assertJsonCount(3, 'data.menus');
+        $response->assertJsonCount(3, 'data.menus.data');
         $response->assertJsonFragment(['id' => (string) $menuHalal->id]);
         $response->assertJsonFragment(['id' => (string) $menuVegan->id]);
         $response->assertJsonFragment(['id' => (string) $menuBoth->id]);

--- a/tests/Feature/MenuPriceQueryTest.php
+++ b/tests/Feature/MenuPriceQueryTest.php
@@ -36,7 +36,9 @@ class MenuPriceQueryTest extends TestCase
         $query = /* @lang GraphQL */ '
             query ($price_between: [Float!]) {
                 menus(price_between: $price_between) {
-                    id
+                    data {
+                        id
+                    }
                 }
             }
         ';
@@ -45,7 +47,7 @@ class MenuPriceQueryTest extends TestCase
             'price_between' => [10, 20],
         ]);
 
-        $response->assertJsonCount(2, 'data.menus');
+        $response->assertJsonCount(2, 'data.menus.data');
         $response->assertJsonFragment(['id' => (string) $menuLow->id]);
         $response->assertJsonFragment(['id' => (string) $menuMid->id]);
         $response->assertJsonMissing(['id' => (string) $menuCheap->id]);

--- a/tests/Feature/MenuTypeQueryTest.php
+++ b/tests/Feature/MenuTypeQueryTest.php
@@ -36,7 +36,9 @@ class MenuTypeQueryTest extends TestCase
         $query = /* @lang GraphQL */ '
             query ($types: [String!]) {
                 menus(types: $types) {
-                    id
+                    data {
+                        id
+                    }
                 }
             }
         ';
@@ -45,7 +47,7 @@ class MenuTypeQueryTest extends TestCase
             'types' => ['plat', 'dessert'],
         ]);
 
-        $response->assertJsonCount(2, 'data.menus');
+        $response->assertJsonCount(2, 'data.menus.data');
         $response->assertJsonFragment(['id' => (string) $menuPlat->id]);
         $response->assertJsonFragment(['id' => (string) $menuDessert->id]);
         $response->assertJsonMissing(['id' => (string) $menuEntree->id]);


### PR DESCRIPTION
## Summary
- apply Lighthouse pagination to the menus query so results are limited and include pagination metadata
- update menu GraphQL feature tests to expect paginated response shapes

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68cc2e7b7258832d82e746a19eac4e71