### PR TITLE
Handle platform specific not null alteration for public menu card URL

### DIFF
--- a/database/migrations/2025_09_21_000000_add_public_menu_card_settings_to_companies_table.php
+++ b/database/migrations/2025_09_21_000000_add_public_menu_card_settings_to_companies_table.php
@@ -63,9 +63,18 @@ return new class extends Migration
         }
 
         if (Schema::hasColumn('companies', 'public_menu_card_url')) {
-            DB::statement(
-                'ALTER TABLE companies ALTER COLUMN public_menu_card_url SET NOT NULL'
-            );
+            $driver = DB::getDriverName();
+
+            $statements = [
+                'pgsql' => 'ALTER TABLE companies ALTER COLUMN public_menu_card_url SET NOT NULL',
+                'mysql' => 'ALTER TABLE companies MODIFY public_menu_card_url VARCHAR(255) NOT NULL',
+                'mariadb' => 'ALTER TABLE companies MODIFY public_menu_card_url VARCHAR(255) NOT NULL',
+                'sqlsrv' => 'ALTER TABLE companies ALTER COLUMN public_menu_card_url NVARCHAR(255) NOT NULL',
+            ];
+
+            if (array_key_exists($driver, $statements)) {
+                DB::statement($statements[$driver]);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- update the companies public menu card migration to use driver-specific SQL for enforcing the NOT NULL constraint
- avoid executing unsupported ALTER statements on SQLite while keeping support for PostgreSQL, MySQL/MariaDB, and SQL Server

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68cdf1e01e3c832db4d3b6f2e2236b77