### PR TITLE
Avoid soft deleting consumed perishable lots

### DIFF
--- a/app/Services/PerishableService.php
+++ b/app/Services/PerishableService.php
@@ -70,15 +70,19 @@ class PerishableService
                 break;
             }
 
-            $remove = min($perishable->quantity, $quantity);
-            $perishable->quantity -= $remove;
-            $quantity -= $remove;
+            $currentQuantity = (float) $perishable->quantity;
+            $remove = min($currentQuantity, $quantity);
+            $remaining = round($currentQuantity - $remove, 2);
+            $quantity = max(0, round($quantity - $remove, 2));
 
-            if ($perishable->quantity <= 0) {
-                $perishable->delete();
-            } else {
-                $perishable->save();
+            if ($remaining <= 0) {
+                $perishable->forceDelete();
+
+                continue;
             }
+
+            $perishable->quantity = $remaining;
+            $perishable->save();
         }
     }
 

--- a/tests/Unit/PerishableTest.php
+++ b/tests/Unit/PerishableTest.php
@@ -64,6 +64,7 @@ class PerishableTest extends TestCase
         $service->remove($ingredient->id, $location->id, $company->id, 3);
 
         $this->assertSame(2, Perishable::count());
+        $this->assertSame(0, Perishable::onlyTrashed()->count());
         $this->assertDatabaseHas('perishables', [
             'ingredient_id' => $ingredient->id,
             'location_id' => $location->id,


### PR DESCRIPTION
## Summary
- force delete perishable lots that are fully consumed so only expired lots remain soft deleted
- round remaining quantities when removing stock to avoid precision issues
- extend perishable removal unit test to assert no soft-deleted lots are created

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68cebb18ab8c832dacdf1c4e3f6402c9