### PR TITLE
Add endpoint to create simple orders

### DIFF
--- a/routes/authed_route.php
+++ b/routes/authed_route.php
@@ -154,6 +154,7 @@ Route::prefix('rooms')->name('rooms.')->group(function () {
 
 // Groupe de routes pour les commandes
 Route::prefix('orders')->name('orders.')->group(function () {
+    Route::post('/', [OrderController::class, 'store'])->name('store');
     Route::post('/{order}/pay', [OrderController::class, 'markPayed'])->name('pay');
     Route::post('/{order}/steps', [OrderController::class, 'storeStep'])->name('steps.store');
     Route::post('/{order}/steps/{step}/menus', [OrderController::class, 'storeStepMenu'])->name('steps.menus.store');


### PR DESCRIPTION
## Summary
- add a POST /api/orders endpoint that creates pending orders for the authenticated company and returns hydrated data
- ensure the new controller method validates table ownership before persisting
- cover the creation flow and validation edge cases with feature tests

## Testing
- ./vendor/bin/pint
- ./vendor/bin/phpstan analyse
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68d025499794832db152b454a255990f