### PR TITLE
Seed order histories and extend GraphQL coverage

### DIFF
--- a/app/Enums/OrderHistoryAction.php
+++ b/app/Enums/OrderHistoryAction.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Enums;
+
+enum OrderHistoryAction: string
+{
+    case ORDER_CREATED = 'order.created';
+    case ORDER_STATUS_UPDATED = 'order.status_updated';
+    case ORDER_STEP_CREATED = 'order_step.created';
+    case ORDER_STEP_STATUS_UPDATED = 'order_step.status_updated';
+    case STEP_MENU_ADDED = 'step_menu.added';
+    case STEP_MENU_UPDATED = 'step_menu.updated';
+    case STEP_MENU_REMOVED = 'step_menu.removed';
+    case STEP_MENU_STATUS_UPDATED = 'step_menu.status_updated';
+
+    /**
+     * @return array<int, string>
+     */
+    public static function values(): array
+    {
+        return array_map(static fn (self $action): string => $action->value, self::cases());
+    }
+}

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -67,6 +67,11 @@ class Order extends Model
         return $this->hasMany(OrderStep::class);
     }
 
+    public function histories(): HasMany
+    {
+        return $this->hasMany(OrderHistory::class)->orderBy('created_at');
+    }
+
     public function menus(): HasManyThrough
     {
         return $this->hasManyThrough(

--- a/app/Models/OrderHistory.php
+++ b/app/Models/OrderHistory.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class OrderHistory extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'order_id',
+        'order_step_id',
+        'step_menu_id',
+        'company_id',
+        'user_id',
+        'action',
+        'payload',
+        'reason',
+    ];
+
+    protected $casts = [
+        'payload' => 'array',
+    ];
+
+    public function order(): BelongsTo
+    {
+        return $this->belongsTo(Order::class);
+    }
+
+    public function orderStep(): BelongsTo
+    {
+        return $this->belongsTo(OrderStep::class);
+    }
+
+    public function stepMenu(): BelongsTo
+    {
+        return $this->belongsTo(StepMenu::class);
+    }
+
+    public function company(): BelongsTo
+    {
+        return $this->belongsTo(Company::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Services/OrderHistoryService.php
+++ b/app/Services/OrderHistoryService.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\OrderHistoryAction;
+use App\Enums\OrderStatus;
+use App\Enums\OrderStepStatus;
+use App\Enums\StepMenuStatus;
+use App\Models\Order;
+use App\Models\OrderHistory;
+use App\Models\OrderStep;
+use App\Models\StepMenu;
+use App\Models\User;
+
+class OrderHistoryService
+{
+    public function record(
+        Order $order,
+        OrderHistoryAction $action,
+        ?User $user = null,
+        ?OrderStep $orderStep = null,
+        ?StepMenu $stepMenu = null,
+        array $payload = [],
+        ?string $reason = null,
+    ): OrderHistory {
+        return OrderHistory::query()->create([
+            'order_id' => $order->id,
+            'order_step_id' => $orderStep?->id,
+            'step_menu_id' => $stepMenu?->id,
+            'company_id' => $order->company_id,
+            'user_id' => $user !== null ? $user->id : auth()->id(),
+            'action' => $action->value,
+            'payload' => $payload === [] ? null : $payload,
+            'reason' => $reason,
+        ]);
+    }
+
+    public function recordOrderStatusChange(
+        Order $order,
+        OrderStatus $from,
+        OrderStatus $to,
+        ?User $user = null,
+        array $additionalPayload = [],
+        ?string $reason = null,
+    ): OrderHistory {
+        $payload = array_merge([
+            'from' => $from->value,
+            'to' => $to->value,
+        ], $additionalPayload);
+
+        return $this->record(
+            order: $order,
+            action: OrderHistoryAction::ORDER_STATUS_UPDATED,
+            user: $user,
+            payload: $payload,
+            reason: $reason,
+        );
+    }
+
+    public function recordStepStatusChange(
+        Order $order,
+        OrderStep $step,
+        OrderStepStatus $from,
+        OrderStepStatus $to,
+        ?User $user = null,
+    ): OrderHistory {
+        return $this->record(
+            order: $order,
+            action: OrderHistoryAction::ORDER_STEP_STATUS_UPDATED,
+            user: $user,
+            orderStep: $step,
+            payload: [
+                'from' => $from->value,
+                'to' => $to->value,
+            ],
+        );
+    }
+
+    public function recordStepMenuStatusChange(
+        Order $order,
+        StepMenu $stepMenu,
+        StepMenuStatus $from,
+        StepMenuStatus $to,
+        ?User $user = null,
+    ): OrderHistory {
+        /** @var OrderStep|null $relatedStep */
+        $relatedStep = $stepMenu->step;
+
+        return $this->record(
+            order: $order,
+            action: OrderHistoryAction::STEP_MENU_STATUS_UPDATED,
+            user: $user,
+            orderStep: $relatedStep,
+            stepMenu: $stepMenu,
+            payload: [
+                'from' => $from->value,
+                'to' => $to->value,
+            ],
+        );
+    }
+}

--- a/database/factories/OrderHistoryFactory.php
+++ b/database/factories/OrderHistoryFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\OrderHistoryAction;
+use App\Models\Company;
+use App\Models\Order;
+use App\Models\OrderHistory;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<OrderHistory>
+ */
+class OrderHistoryFactory extends Factory
+{
+    protected $model = OrderHistory::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'order_id' => Order::factory(),
+            'order_step_id' => null,
+            'step_menu_id' => null,
+            'company_id' => Company::factory(),
+            'user_id' => User::factory(),
+            'action' => OrderHistoryAction::ORDER_CREATED->value,
+            'payload' => [],
+            'reason' => null,
+        ];
+    }
+}

--- a/database/migrations/2025_09_22_000000_create_order_histories_table.php
+++ b/database/migrations/2025_09_22_000000_create_order_histories_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('order_histories', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('order_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('order_step_id')->nullable()->constrained('order_steps')->nullOnDelete();
+            $table->foreignId('step_menu_id')->nullable()->constrained('step_menus')->nullOnDelete();
+            $table->foreignId('company_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+
+            $table->string('action');
+            $table->json('payload')->nullable();
+            $table->string('reason')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('order_histories');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -29,6 +29,7 @@ class DatabaseSeeder extends Seeder
             OrderSeeder::class,
             OrderStepSeeder::class,
             StepMenuSeeder::class,
+            OrderHistorySeeder::class,
         ]);
     }
 }

--- a/database/seeders/OrderHistorySeeder.php
+++ b/database/seeders/OrderHistorySeeder.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\OrderHistoryAction;
+use App\Enums\OrderStatus;
+use App\Enums\OrderStepStatus;
+use App\Enums\StepMenuStatus;
+use App\Models\Order;
+use App\Models\OrderStep;
+use App\Models\StepMenu;
+use App\Models\User;
+use App\Services\OrderHistoryService;
+use Illuminate\Database\Seeder;
+
+class OrderHistorySeeder extends Seeder
+{
+    public function run(): void
+    {
+        /** @var OrderHistoryService $historyService */
+        $historyService = app(OrderHistoryService::class);
+
+        $orders = Order::query()
+            ->with(['user', 'steps.stepMenus'])
+            ->get();
+
+        foreach ($orders as $order) {
+            if ($order->histories()->exists()) {
+                continue;
+            }
+
+            $user = $order->user;
+
+            $historyService->record(
+                order: $order,
+                action: OrderHistoryAction::ORDER_CREATED,
+                user: $user,
+                payload: [
+                    'table_id' => $order->table_id,
+                    'status' => $order->status->value,
+                ],
+            );
+
+            /** @var OrderStep $step */
+            foreach ($order->steps as $step) {
+                $historyService->record(
+                    order: $order,
+                    action: OrderHistoryAction::ORDER_STEP_CREATED,
+                    user: $user,
+                    orderStep: $step,
+                    payload: [
+                        'position' => $step->position,
+                    ],
+                );
+
+                $this->seedStepStatusHistory($historyService, $order, $step, $user);
+
+                /** @var StepMenu $stepMenu */
+                foreach ($step->stepMenus as $stepMenu) {
+                    $historyService->record(
+                        order: $order,
+                        action: OrderHistoryAction::STEP_MENU_ADDED,
+                        user: $user,
+                        orderStep: $step,
+                        stepMenu: $stepMenu,
+                        payload: [
+                            'menu_id' => $stepMenu->menu_id,
+                            'quantity' => $stepMenu->quantity,
+                            'status' => $stepMenu->status->value,
+                            'note' => $stepMenu->note,
+                        ],
+                    );
+
+                    $this->seedStepMenuStatusHistory($historyService, $order, $step, $stepMenu, $user);
+                }
+            }
+
+            $this->seedOrderStatusHistory($historyService, $order, $user);
+        }
+    }
+
+    private function seedStepStatusHistory(OrderHistoryService $historyService, Order $order, OrderStep $step, ?User $user): void
+    {
+        foreach ($this->stepStatusTransitions($step->status) as [$from, $to]) {
+            $historyService->recordStepStatusChange(
+                order: $order,
+                step: $step,
+                from: $from,
+                to: $to,
+                user: $user,
+            );
+        }
+    }
+
+    /**
+     * @return array<int, array{0: OrderStepStatus, 1: OrderStepStatus}>
+     */
+    private function stepStatusTransitions(OrderStepStatus $status): array
+    {
+        return match ($status) {
+            OrderStepStatus::IN_PREP => [],
+            OrderStepStatus::READY => [
+                [OrderStepStatus::IN_PREP, OrderStepStatus::READY],
+            ],
+            OrderStepStatus::SERVED => [
+                [OrderStepStatus::IN_PREP, OrderStepStatus::READY],
+                [OrderStepStatus::READY, OrderStepStatus::SERVED],
+            ],
+        };
+    }
+
+    private function seedStepMenuStatusHistory(
+        OrderHistoryService $historyService,
+        Order $order,
+        OrderStep $step,
+        StepMenu $stepMenu,
+        ?User $user,
+    ): void {
+        foreach ($this->stepMenuStatusTransitions($stepMenu->status) as [$from, $to]) {
+            $historyService->recordStepMenuStatusChange(
+                order: $order,
+                stepMenu: $stepMenu,
+                from: $from,
+                to: $to,
+                user: $user,
+            );
+        }
+    }
+
+    /**
+     * @return array<int, array{0: StepMenuStatus, 1: StepMenuStatus}>
+     */
+    private function stepMenuStatusTransitions(StepMenuStatus $status): array
+    {
+        return match ($status) {
+            StepMenuStatus::IN_PREP => [],
+            StepMenuStatus::READY => [
+                [StepMenuStatus::IN_PREP, StepMenuStatus::READY],
+            ],
+            StepMenuStatus::SERVED => [
+                [StepMenuStatus::IN_PREP, StepMenuStatus::READY],
+                [StepMenuStatus::READY, StepMenuStatus::SERVED],
+            ],
+        };
+    }
+
+    private function seedOrderStatusHistory(OrderHistoryService $historyService, Order $order, ?User $user): void
+    {
+        foreach ($this->orderStatusTransitions($order) as $transition) {
+            $historyService->recordOrderStatusChange(
+                order: $order,
+                from: $transition['from'],
+                to: $transition['to'],
+                user: $user,
+                additionalPayload: $transition['payload'],
+                reason: $transition['reason'],
+            );
+        }
+    }
+
+    /**
+     * @return array<int, array{from: OrderStatus, to: OrderStatus, payload: array<string, mixed>, reason: string|null}>
+     */
+    private function orderStatusTransitions(Order $order): array
+    {
+        return match ($order->status) {
+            OrderStatus::PENDING => [],
+            OrderStatus::SERVED => [
+                [
+                    'from' => OrderStatus::PENDING,
+                    'to' => OrderStatus::SERVED,
+                    'payload' => [],
+                    'reason' => null,
+                ],
+            ],
+            OrderStatus::PAYED => [
+                [
+                    'from' => OrderStatus::PENDING,
+                    'to' => OrderStatus::SERVED,
+                    'payload' => [],
+                    'reason' => null,
+                ],
+                [
+                    'from' => OrderStatus::SERVED,
+                    'to' => OrderStatus::PAYED,
+                    'payload' => ['force' => false],
+                    'reason' => null,
+                ],
+            ],
+            OrderStatus::CANCELED => [
+                [
+                    'from' => OrderStatus::PENDING,
+                    'to' => OrderStatus::CANCELED,
+                    'payload' => [
+                        'loss_step_menu_ids' => [],
+                        'return_step_menu_ids' => [],
+                    ],
+                    'reason' => 'ORDER_CANCELED',
+                ],
+            ],
+        };
+    }
+}

--- a/graphql/models/order.graphql
+++ b/graphql/models/order.graphql
@@ -35,6 +35,9 @@ type Order {
     "Étapes associées à la commande."
     steps: [OrderStep!]! @hasMany
 
+    "Historique des actions liées à la commande (ordre chronologique)."
+    histories: [OrderHistory!]! @hasMany
+
     "Date de création de la commande."
     created_at: DateTime!
 

--- a/graphql/models/orderHistory.graphql
+++ b/graphql/models/orderHistory.graphql
@@ -1,0 +1,47 @@
+"Historique des actions effectuées sur une commande."
+type OrderHistory {
+    "Identifiant unique de l'entrée."
+    id: ID!
+
+    "Commande associée à l'entrée."
+    order: Order! @belongsTo
+
+    "Étape concernée, le cas échéant."
+    order_step: OrderStep @belongsTo
+
+    "Menu d'étape concerné, le cas échéant."
+    step_menu: StepMenu @belongsTo
+
+    "Entreprise liée à l'entrée."
+    company: Company! @belongsTo
+
+    "Utilisateur ayant réalisé l'action."
+    user: User @belongsTo
+
+    "Type d'action enregistrée."
+    action: OrderHistoryActionEnum!
+
+    "Informations métier associées à l'action."
+    payload: JSON
+
+    "Raison associée à l'action (si applicable)."
+    reason: String
+
+    "Date de création de l'entrée."
+    created_at: DateTime!
+
+    "Date de dernière mise à jour."
+    updated_at: DateTime!
+}
+
+"Liste des actions possibles sur l'historique des commandes."
+enum OrderHistoryActionEnum {
+    ORDER_CREATED @enum(value: "order.created")
+    ORDER_STATUS_UPDATED @enum(value: "order.status_updated")
+    ORDER_STEP_CREATED @enum(value: "order_step.created")
+    ORDER_STEP_STATUS_UPDATED @enum(value: "order_step.status_updated")
+    STEP_MENU_ADDED @enum(value: "step_menu.added")
+    STEP_MENU_UPDATED @enum(value: "step_menu.updated")
+    STEP_MENU_REMOVED @enum(value: "step_menu.removed")
+    STEP_MENU_STATUS_UPDATED @enum(value: "step_menu.status_updated")
+}

--- a/tests/Feature/OrderHistoryTest.php
+++ b/tests/Feature/OrderHistoryTest.php
@@ -1,0 +1,375 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\MenuServiceType;
+use App\Enums\OrderHistoryAction;
+use App\Enums\OrderStatus;
+use App\Enums\OrderStepStatus;
+use App\Enums\StepMenuStatus;
+use App\Models\Menu;
+use App\Models\Order;
+use App\Models\OrderHistory;
+use App\Models\OrderStep;
+use App\Models\Room;
+use App\Models\StepMenu;
+use App\Models\Table;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Tests\TestCase;
+
+class OrderHistoryTest extends TestCase
+{
+    use MakesGraphQLRequests;
+    use RefreshDatabase;
+
+    private function createTableForUser(User $user): Table
+    {
+        $room = Room::factory()->for($user->company)->create();
+
+        return Table::factory()
+            ->for($room, 'room')
+            ->for($user->company)
+            ->create();
+    }
+
+    private function createMenuForUser(User $user, array $attributes = []): Menu
+    {
+        return Menu::factory()->create(array_merge([
+            'company_id' => $user->company_id,
+            'service_type' => MenuServiceType::PREP,
+            'price' => 12.5,
+        ], $attributes));
+    }
+
+    public function test_it_records_order_creation_and_step_creation(): void
+    {
+        $user = User::factory()->create();
+        $table = $this->createTableForUser($user);
+        $menu = $this->createMenuForUser($user);
+
+        $orderResponse = $this->actingAs($user)->postJson('/api/orders', [
+            'table_id' => $table->id,
+        ]);
+
+        $orderResponse->assertCreated();
+
+        $orderId = (int) $orderResponse->json('order.id');
+        $order = Order::findOrFail($orderId);
+
+        $historyAfterCreation = OrderHistory::where('order_id', $orderId)->get();
+        self::assertTrue(
+            $historyAfterCreation->contains(fn (OrderHistory $entry) => $entry->action === OrderHistoryAction::ORDER_CREATED->value)
+        );
+
+        $this->actingAs($user)->postJson("/api/orders/{$orderId}/steps", [
+            'menus' => [
+                [
+                    'menu_id' => $menu->id,
+                    'quantity' => 2,
+                ],
+            ],
+        ])->assertCreated();
+
+        $histories = OrderHistory::where('order_id', $orderId)
+            ->orderBy('created_at')
+            ->get();
+
+        self::assertTrue(
+            $histories->contains(fn (OrderHistory $entry) => $entry->action === OrderHistoryAction::ORDER_STEP_CREATED->value)
+        );
+        $menuAddition = $histories->firstWhere('action', OrderHistoryAction::STEP_MENU_ADDED->value);
+        self::assertNotNull($menuAddition);
+        self::assertSame(2, $menuAddition->payload['quantity']);
+        self::assertSame($menu->id, $menuAddition->payload['menu_id']);
+        self::assertSame($user->id, $menuAddition->user_id);
+    }
+
+    public function test_it_records_step_menu_status_transitions(): void
+    {
+        $user = User::factory()->create();
+        $table = $this->createTableForUser($user);
+        $menu = $this->createMenuForUser($user);
+
+        $orderId = (int) $this->actingAs($user)->postJson('/api/orders', [
+            'table_id' => $table->id,
+        ])->assertCreated()->json('order.id');
+
+        $this->actingAs($user)->postJson("/api/orders/{$orderId}/steps", [
+            'menus' => [
+                [
+                    'menu_id' => $menu->id,
+                    'quantity' => 1,
+                ],
+            ],
+        ])->assertCreated();
+
+        $order = Order::with('steps.stepMenus')->findOrFail($orderId);
+        /** @var OrderStep $step */
+        $step = $order->steps->first();
+        /** @var StepMenu $stepMenu */
+        $stepMenu = $step->stepMenus->first();
+
+        $this->actingAs($user)
+            ->postJson("/api/orders/{$orderId}/step-menus/{$stepMenu->id}/ready")
+            ->assertOk();
+
+        $readyMenuHistory = OrderHistory::where('order_id', $orderId)
+            ->where('action', OrderHistoryAction::STEP_MENU_STATUS_UPDATED->value)
+            ->get()
+            ->last(fn (OrderHistory $entry) => ($entry->payload['to'] ?? null) === StepMenuStatus::READY->value);
+
+        self::assertNotNull($readyMenuHistory);
+        self::assertSame(StepMenuStatus::IN_PREP->value, $readyMenuHistory->payload['from']);
+
+        $readyStepHistory = OrderHistory::where('order_id', $orderId)
+            ->where('action', OrderHistoryAction::ORDER_STEP_STATUS_UPDATED->value)
+            ->get()
+            ->last(fn (OrderHistory $entry) => ($entry->payload['to'] ?? null) === OrderStepStatus::READY->value);
+
+        self::assertNotNull($readyStepHistory);
+        self::assertSame(OrderStepStatus::IN_PREP->value, $readyStepHistory->payload['from']);
+
+        $this->actingAs($user)
+            ->postJson("/api/orders/{$orderId}/step-menus/{$stepMenu->id}/served")
+            ->assertOk();
+
+        $servedMenuHistory = OrderHistory::where('order_id', $orderId)
+            ->where('action', OrderHistoryAction::STEP_MENU_STATUS_UPDATED->value)
+            ->get()
+            ->last(fn (OrderHistory $entry) => ($entry->payload['to'] ?? null) === StepMenuStatus::SERVED->value);
+
+        self::assertNotNull($servedMenuHistory);
+        self::assertSame(StepMenuStatus::READY->value, $servedMenuHistory->payload['from']);
+
+        $servedStepHistory = OrderHistory::where('order_id', $orderId)
+            ->where('action', OrderHistoryAction::ORDER_STEP_STATUS_UPDATED->value)
+            ->get()
+            ->last(fn (OrderHistory $entry) => ($entry->payload['to'] ?? null) === OrderStepStatus::SERVED->value);
+
+        self::assertNotNull($servedStepHistory);
+        self::assertSame(OrderStepStatus::READY->value, $servedStepHistory->payload['from']);
+    }
+
+    public function test_it_records_step_menu_cancellations(): void
+    {
+        $user = User::factory()->create();
+        $table = $this->createTableForUser($user);
+        $menu = $this->createMenuForUser($user);
+
+        $orderId = (int) $this->actingAs($user)->postJson('/api/orders', [
+            'table_id' => $table->id,
+        ])->assertCreated()->json('order.id');
+
+        $this->actingAs($user)->postJson("/api/orders/{$orderId}/steps", [
+            'menus' => [
+                [
+                    'menu_id' => $menu->id,
+                    'quantity' => 3,
+                ],
+            ],
+        ])->assertCreated();
+
+        $order = Order::with('steps.stepMenus')->findOrFail($orderId);
+        /** @var StepMenu $stepMenu */
+        $stepMenu = $order->steps->first()->stepMenus->first();
+
+        $this->actingAs($user)
+            ->postJson("/api/orders/{$orderId}/step-menus/{$stepMenu->id}/cancel", [
+                'quantity' => 1,
+            ])
+            ->assertOk();
+
+        $updateHistory = OrderHistory::where('order_id', $orderId)
+            ->where('action', OrderHistoryAction::STEP_MENU_UPDATED->value)
+            ->latest()
+            ->first();
+
+        self::assertNotNull($updateHistory);
+        self::assertSame(3, $updateHistory->payload['quantity_before']);
+        self::assertSame(2, $updateHistory->payload['quantity_after']);
+        self::assertSame(1, $updateHistory->payload['canceled_quantity']);
+        self::assertSame('simple', $updateHistory->payload['type']);
+        self::assertNull($updateHistory->reason);
+
+        $this->actingAs($user)
+            ->postJson("/api/orders/{$orderId}/step-menus/{$stepMenu->id}/cancel", [
+                'quantity' => 2,
+            ])
+            ->assertOk();
+
+        $removalHistory = OrderHistory::where('order_id', $orderId)
+            ->where('action', OrderHistoryAction::STEP_MENU_REMOVED->value)
+            ->latest()
+            ->first();
+
+        self::assertNotNull($removalHistory);
+        self::assertSame(2, $removalHistory->payload['quantity_before']);
+        self::assertSame(0, $removalHistory->payload['quantity_after']);
+        self::assertSame(2, $removalHistory->payload['canceled_quantity']);
+        self::assertSame('simple', $removalHistory->payload['type']);
+        self::assertNull($removalHistory->reason);
+    }
+
+    public function test_it_records_returns_and_order_cancellation(): void
+    {
+        $user = User::factory()->create();
+        $table = $this->createTableForUser($user);
+        $menu = $this->createMenuForUser($user, [
+            'service_type' => MenuServiceType::DIRECT,
+            'is_returnable' => true,
+        ]);
+
+        $orderId = (int) $this->actingAs($user)->postJson('/api/orders', [
+            'table_id' => $table->id,
+        ])->assertCreated()->json('order.id');
+
+        $this->actingAs($user)->postJson("/api/orders/{$orderId}/steps", [
+            'menus' => [
+                [
+                    'menu_id' => $menu->id,
+                    'quantity' => 1,
+                ],
+            ],
+        ])->assertCreated();
+
+        $order = Order::with('steps.stepMenus')->findOrFail($orderId);
+        /** @var StepMenu $stepMenu */
+        $stepMenu = $order->steps->first()->stepMenus->first();
+
+        $this->actingAs($user)
+            ->postJson("/api/orders/{$orderId}/step-menus/{$stepMenu->id}/served")
+            ->assertOk();
+
+        $this->actingAs($user)
+            ->postJson("/api/orders/{$orderId}/cancel", [
+                'unopened_returns' => [$stepMenu->id],
+            ])
+            ->assertOk();
+
+        $returnHistory = OrderHistory::where('order_id', $orderId)
+            ->where('action', OrderHistoryAction::STEP_MENU_REMOVED->value)
+            ->latest()
+            ->first();
+
+        self::assertNotNull($returnHistory);
+        self::assertSame('return', $returnHistory->payload['type']);
+        self::assertTrue($returnHistory->payload['return_accepted']);
+        self::assertSame('RETURN_ACCEPTED', $returnHistory->reason);
+
+        $orderStatusHistory = OrderHistory::where('order_id', $orderId)
+            ->where('action', OrderHistoryAction::ORDER_STATUS_UPDATED->value)
+            ->latest()
+            ->first();
+
+        self::assertNotNull($orderStatusHistory);
+        self::assertSame(OrderStatus::PENDING->value, $orderStatusHistory->payload['from']);
+        self::assertSame(OrderStatus::CANCELED->value, $orderStatusHistory->payload['to']);
+        self::assertSame('ORDER_CANCELED', $orderStatusHistory->reason);
+        self::assertSame([$stepMenu->id], $orderStatusHistory->payload['return_step_menu_ids']);
+    }
+
+    public function test_it_records_order_payment(): void
+    {
+        $user = User::factory()->create();
+        $table = $this->createTableForUser($user);
+        $menu = $this->createMenuForUser($user);
+
+        $orderId = (int) $this->actingAs($user)->postJson('/api/orders', [
+            'table_id' => $table->id,
+        ])->assertCreated()->json('order.id');
+
+        $this->actingAs($user)->postJson("/api/orders/{$orderId}/steps", [
+            'menus' => [
+                [
+                    'menu_id' => $menu->id,
+                    'quantity' => 1,
+                ],
+            ],
+        ])->assertCreated();
+
+        $order = Order::with('steps.stepMenus')->findOrFail($orderId);
+        /** @var StepMenu $stepMenu */
+        $stepMenu = $order->steps->first()->stepMenus->first();
+
+        $this->actingAs($user)
+            ->postJson("/api/orders/{$orderId}/step-menus/{$stepMenu->id}/ready")
+            ->assertOk();
+
+        $this->actingAs($user)
+            ->postJson("/api/orders/{$orderId}/step-menus/{$stepMenu->id}/served")
+            ->assertOk();
+
+        $this->actingAs($user)
+            ->postJson("/api/orders/{$orderId}/pay")
+            ->assertOk();
+
+        $history = OrderHistory::where('order_id', $orderId)
+            ->where('action', OrderHistoryAction::ORDER_STATUS_UPDATED->value)
+            ->latest()
+            ->first();
+
+        self::assertNotNull($history);
+        self::assertSame(OrderStatus::PENDING->value, $history->payload['from']);
+        self::assertSame(OrderStatus::PAYED->value, $history->payload['to']);
+        self::assertFalse($history->payload['force']);
+        self::assertNull($history->reason);
+    }
+
+    public function test_order_history_is_available_through_graphql(): void
+    {
+        $user = User::factory()->create();
+        $table = $this->createTableForUser($user);
+
+        $order = Order::create([
+            'table_id' => $table->id,
+            'company_id' => $user->company_id,
+            'user_id' => $user->id,
+            'status' => OrderStatus::PENDING,
+            'pending_at' => now(),
+        ]);
+
+        OrderHistory::factory()->for($order)
+            ->create([
+                'company_id' => $order->company_id,
+                'user_id' => $user->id,
+                'action' => OrderHistoryAction::ORDER_CREATED->value,
+                'payload' => ['status' => OrderStatus::PENDING->value],
+                'created_at' => now()->subMinutes(2),
+            ]);
+
+        OrderHistory::factory()->for($order)
+            ->create([
+                'company_id' => $order->company_id,
+                'user_id' => $user->id,
+                'action' => OrderHistoryAction::ORDER_STATUS_UPDATED->value,
+                'payload' => [
+                    'from' => OrderStatus::PENDING->value,
+                    'to' => OrderStatus::SERVED->value,
+                ],
+                'reason' => 'ORDER_SERVED',
+                'created_at' => now()->subMinute(),
+            ]);
+
+        $query = /** @lang GraphQL */ 'query ($id: ID!) {
+            order(id: $id) {
+                id
+                histories {
+                    action
+                    reason
+                    payload
+                }
+            }
+        }';
+
+        $response = $this->actingAs($user)->graphQL($query, ['id' => $order->id]);
+
+        $response->assertJsonPath('data.order.histories.0.action', OrderHistoryAction::ORDER_CREATED->name);
+        $response->assertJsonPath('data.order.histories.1.action', OrderHistoryAction::ORDER_STATUS_UPDATED->name);
+        $response->assertJsonPath('data.order.histories.0.payload.status', OrderStatus::PENDING->value);
+        $response->assertJsonPath('data.order.histories.0.reason', null);
+        $response->assertJsonPath('data.order.histories.1.payload.to', OrderStatus::SERVED->value);
+        $response->assertJsonPath('data.order.histories.1.reason', 'ORDER_SERVED');
+    }
+}


### PR DESCRIPTION
## Summary
- seed deterministic order history entries for seeded orders, steps, and menus using a dedicated seeder
- register the history seeder and tighten the order history service's relation handling
- expand the order history GraphQL test to assert payload and reason fields

## Testing
- php artisan test
- ./vendor/bin/phpstan analyse
- ./vendor/bin/pint

------
https://chatgpt.com/codex/tasks/task_e_68d06c1b9ab4832da7c27d2f460ca1f3