### PR TITLE
feat: seed business hours and extend company settings tests

### DIFF
--- a/app/Http/Controllers/CompanyController.php
+++ b/app/Http/Controllers/CompanyController.php
@@ -2,9 +2,16 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\UpdateCompanyBusinessHoursRequest;
+use App\Http\Requests\UpdateCompanyContactRequest;
+use App\Http\Requests\UpdateCompanyImageRequest;
 use App\Http\Requests\UpdateCompanyOptionsRequest;
 use App\Models\Company;
+use App\Models\CompanyBusinessHour;
+use App\Services\ImageService;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
 
 class CompanyController extends Controller
 {
@@ -29,34 +36,223 @@ class CompanyController extends Controller
 
         $validated = $request->validated();
 
-        if (array_key_exists('open_food_facts_language', $validated)) {
-            $company->open_food_facts_language = $validated['open_food_facts_language'];
+        $attributes = Arr::only($validated, [
+            'open_food_facts_language',
+            'public_menu_card_url',
+            'show_out_of_stock_menus_on_card',
+            'show_menu_images',
+        ]);
+
+        if ($attributes !== []) {
+            $company->fill($attributes);
+            $company->save();
         }
 
-        if (array_key_exists('public_menu_card_url', $validated)) {
-            $company->public_menu_card_url = $validated['public_menu_card_url'];
+        return $this->buildCompanyResponse($company, 'Options mises à jour avec succès');
+    }
+
+    public function updateContact(UpdateCompanyContactRequest $request): JsonResponse
+    {
+        $user = $request->user();
+        /** @var Company $company */
+        $company = $user->company;
+
+        $attributes = Arr::only($request->validated(), [
+            'contact_name',
+            'contact_email',
+            'contact_phone',
+            'address_line',
+            'postal_code',
+            'city',
+            'country',
+        ]);
+
+        if ($attributes !== []) {
+            $company->fill($attributes);
+            $company->save();
         }
 
-        if (array_key_exists('show_out_of_stock_menus_on_card', $validated)) {
-            $company->show_out_of_stock_menus_on_card = $validated['show_out_of_stock_menus_on_card'];
+        return $this->buildCompanyResponse($company, 'Coordonnées mises à jour avec succès');
+    }
+
+    public function updateBusinessHours(UpdateCompanyBusinessHoursRequest $request): JsonResponse
+    {
+        $user = $request->user();
+        /** @var Company $company */
+        $company = $user->company;
+
+        $validated = $request->validated();
+
+        DB::transaction(function () use ($company, $validated) {
+            $this->syncBusinessHours($company, $validated['business_hours'] ?? []);
+        });
+
+        return $this->buildCompanyResponse($company, 'Horaires mis à jour avec succès');
+    }
+
+    public function updateLogo(UpdateCompanyImageRequest $request, ImageService $imageService): JsonResponse
+    {
+        $user = $request->user();
+        /** @var Company $company */
+        $company = $user->company;
+
+        $validated = $request->validated();
+
+        $newPath = null;
+
+        if ($request->hasFile('image')) {
+            $newPath = $imageService->store($request->file('image'), 'companies');
+        } elseif (! empty($validated['image_url'])) {
+            $newPath = $imageService->storeFromUrl($validated['image_url'], 'companies');
         }
 
-        if (array_key_exists('show_menu_images', $validated)) {
-            $company->show_menu_images = $validated['show_menu_images'];
+        if (! $newPath) {
+            return response()->json([
+                'message' => "Aucune image n'a été fournie",
+            ], 422);
         }
 
-        $company->save();
+        $previousPath = $company->logo_path;
+
+        if ($newPath !== $previousPath) {
+            $company->logo_path = $newPath;
+            $company->save();
+
+            if ($previousPath) {
+                $imageService->delete($previousPath);
+            }
+        }
+
+        return $this->buildCompanyResponse($company, "Image de l'entreprise mise à jour avec succès");
+    }
+
+    private function buildCompanyResponse(Company $company, string $message): JsonResponse
+    {
+        $company->refresh();
+        $company->load('businessHours');
 
         return response()->json([
-            'message' => 'Options mises à jour avec succès',
-            'data' => [
-                'open_food_facts_language' => $company->open_food_facts_language,
-                'public_menu_card_url' => $company->public_menu_card_url,
-                'show_out_of_stock_menus_on_card' => $company->show_out_of_stock_menus_on_card,
-                'show_menu_images' => $company->show_menu_images,
-                'only_sufficient_stock' => ! $company->show_out_of_stock_menus_on_card,
-                'with_pictures' => $company->show_menu_images,
-            ],
+            'message' => $message,
+            'data' => $this->formatCompanyData($company),
         ]);
+    }
+
+    private function formatCompanyData(Company $company): array
+    {
+        return [
+            'open_food_facts_language' => $company->open_food_facts_language,
+            'public_menu_card_url' => $company->public_menu_card_url,
+            'show_out_of_stock_menus_on_card' => $company->show_out_of_stock_menus_on_card,
+            'show_menu_images' => $company->show_menu_images,
+            'only_sufficient_stock' => ! $company->show_out_of_stock_menus_on_card,
+            'with_pictures' => $company->show_menu_images,
+            'logo_path' => $company->logo_path,
+            'contact_name' => $company->contact_name,
+            'contact_email' => $company->contact_email,
+            'contact_phone' => $company->contact_phone,
+            'address_line' => $company->address_line,
+            'postal_code' => $company->postal_code,
+            'city' => $company->city,
+            'country' => $company->country,
+            'business_hours' => $company->businessHours
+                ->map(fn (CompanyBusinessHour $hour) => [
+                    'id' => $hour->id,
+                    'day_of_week' => $hour->day_of_week,
+                    'opens_at' => $this->formatTimeForResponse($hour->opens_at),
+                    'closes_at' => $this->formatTimeForResponse($hour->closes_at),
+                    'is_overnight' => $hour->is_overnight,
+                    'sequence' => $hour->sequence,
+                ])
+                ->values()
+                ->all(),
+        ];
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $businessHours
+     */
+    private function syncBusinessHours(Company $company, array $businessHours): void
+    {
+        $grouped = [];
+
+        foreach ($businessHours as $entry) {
+            $day = (int) $entry['day_of_week'];
+            $opensAt = $this->normalizeTimeInput($entry['opens_at']);
+            $closesAt = $this->normalizeTimeInput($entry['closes_at']);
+
+            $openMinutes = $this->timeToMinutes($opensAt);
+            $closeMinutes = $this->timeToMinutes($closesAt);
+
+            $isOvernight = (bool) ($entry['is_overnight'] ?? false);
+
+            if ($closeMinutes <= $openMinutes) {
+                $isOvernight = true;
+            }
+
+            $grouped[$day][] = [
+                'day_of_week' => $day,
+                'opens_at' => $this->toDatabaseTime($opensAt),
+                'closes_at' => $this->toDatabaseTime($closesAt),
+                'is_overnight' => $isOvernight,
+                'open_minutes' => $openMinutes,
+            ];
+        }
+
+        ksort($grouped);
+
+        $records = [];
+
+        foreach ($grouped as $day => $entries) {
+            usort($entries, fn ($a, $b) => $a['open_minutes'] <=> $b['open_minutes']);
+
+            foreach ($entries as $index => $entry) {
+                $records[] = [
+                    'day_of_week' => $day,
+                    'opens_at' => $entry['opens_at'],
+                    'closes_at' => $entry['closes_at'],
+                    'is_overnight' => $entry['is_overnight'],
+                    'sequence' => $index + 1,
+                ];
+            }
+        }
+
+        $company->businessHours()->delete();
+
+        if ($records !== []) {
+            $company->businessHours()->createMany($records);
+        }
+    }
+
+    private function normalizeTimeInput(string $time): string
+    {
+        $parts = explode(':', $time);
+
+        $hour = (int) ($parts[0] ?? 0);
+        $minute = (int) ($parts[1] ?? 0);
+
+        return sprintf('%02d:%02d', $hour, $minute);
+    }
+
+    private function toDatabaseTime(string $time): string
+    {
+        return $time.':00';
+    }
+
+    private function timeToMinutes(string $time): int
+    {
+        $parts = explode(':', $time);
+        $hour = (int) ($parts[0] ?? 0);
+        $minute = (int) ($parts[1] ?? 0);
+
+        return ($hour * 60) + $minute;
+    }
+
+    private function formatTimeForResponse(?string $time): ?string
+    {
+        if (! is_string($time) || $time === '') {
+            return null;
+        }
+
+        return substr($time, 0, 5);
     }
 }

--- a/app/Http/Requests/UpdateCompanyBusinessHoursRequest.php
+++ b/app/Http/Requests/UpdateCompanyBusinessHoursRequest.php
@@ -1,0 +1,291 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Validator;
+
+class UpdateCompanyBusinessHoursRequest extends FormRequest
+{
+    private array $invalidBusinessHourKeys = [];
+
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if ($this->exists('business_hours') && is_array($this->input('business_hours'))) {
+            $this->merge([
+                'business_hours' => $this->normalizeBusinessHoursInput($this->input('business_hours')),
+            ]);
+        }
+    }
+
+    public function rules(): array
+    {
+        return [
+            'business_hours' => 'present|array',
+            'business_hours.*' => 'array',
+            'business_hours.*.day_of_week' => 'required_with:business_hours|integer|between:1,7',
+            'business_hours.*.opens_at' => 'required_with:business_hours|string|date_format:H:i',
+            'business_hours.*.closes_at' => 'required_with:business_hours|string|date_format:H:i',
+            'business_hours.*.is_overnight' => 'sometimes|boolean',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'business_hours.*.day_of_week.between' => 'Le jour de la semaine doit être compris entre 1 (lundi) et 7 (dimanche).',
+            'business_hours.*.opens_at.date_format' => "L'heure d'ouverture doit être au format HH:MM.",
+            'business_hours.*.closes_at.date_format' => "L'heure de fermeture doit être au format HH:MM.",
+        ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator) {
+            foreach ($this->invalidBusinessHourKeys as $invalidKey) {
+                $validator->errors()->add('business_hours', sprintf('Le jour "%s" est invalide pour les horaires.', $invalidKey));
+            }
+
+            $entries = $this->input('business_hours');
+
+            if (! is_array($entries) || $entries === []) {
+                return;
+            }
+
+            $normalized = [];
+
+            foreach ($entries as $index => $entry) {
+                if (! is_array($entry)) {
+                    $validator->errors()->add("business_hours.{$index}", 'Format invalide pour les horaires.');
+
+                    continue;
+                }
+
+                if (! array_key_exists('day_of_week', $entry) || ! array_key_exists('opens_at', $entry) || ! array_key_exists('closes_at', $entry)) {
+                    continue;
+                }
+
+                $day = (int) $entry['day_of_week'];
+                $opensAt = $entry['opens_at'];
+                $closesAt = $entry['closes_at'];
+
+                if (! is_string($opensAt) || ! is_string($closesAt)) {
+                    continue;
+                }
+
+                $openMinutes = $this->timeStringToMinutes($opensAt);
+                $closeMinutes = $this->timeStringToMinutes($closesAt);
+
+                if ($openMinutes === $closeMinutes) {
+                    $validator->errors()->add("business_hours.{$index}.closes_at", 'Les heures d’ouverture et de fermeture doivent être différentes.');
+
+                    continue;
+                }
+
+                $isOvernight = (bool) ($entry['is_overnight'] ?? false);
+
+                if ($closeMinutes < $openMinutes && ! $isOvernight) {
+                    $validator->errors()->add("business_hours.{$index}.closes_at", 'Cet horaire se termine avant son ouverture. Activez is_overnight pour un service après minuit.');
+
+                    continue;
+                }
+
+                if ($closeMinutes < $openMinutes) {
+                    $isOvernight = true;
+                }
+
+                $dayIndex = $day - 1;
+
+                if ($dayIndex < 0 || $dayIndex > 6) {
+                    continue;
+                }
+
+                $start = ($dayIndex * 1440) + $openMinutes;
+                $end = ($dayIndex * 1440) + $closeMinutes + ($isOvernight ? 1440 : 0);
+
+                $normalized[] = [
+                    'start' => $start,
+                    'end' => $end,
+                    'index' => $index,
+                ];
+            }
+
+            usort($normalized, fn ($a, $b) => $a['start'] <=> $b['start']);
+
+            for ($i = 1, $count = count($normalized); $i < $count; $i++) {
+                $previous = $normalized[$i - 1];
+                $current = $normalized[$i];
+
+                if ($current['start'] < $previous['end']) {
+                    $validator->errors()->add("business_hours.{$current['index']}.opens_at", 'Les horaires se chevauchent.');
+                }
+            }
+
+            if (count($normalized) > 1) {
+                $first = $normalized[0];
+                $last = $normalized[array_key_last($normalized)];
+                $weekMinutes = 7 * 24 * 60;
+
+                if (($first['start'] + $weekMinutes) < $last['end']) {
+                    $validator->errors()->add("business_hours.{$first['index']}.opens_at", 'Les horaires se chevauchent entre dimanche et lundi.');
+                }
+            }
+        });
+    }
+
+    /**
+     * @param  array<mixed>  $input
+     * @return array<int, array<string, mixed>>
+     */
+    private function normalizeBusinessHoursInput(array $input): array
+    {
+        if ($input === []) {
+            return [];
+        }
+
+        if (array_is_list($input)) {
+            return array_values(array_map(function ($entry) {
+                if (! is_array($entry)) {
+                    return [];
+                }
+
+                if (array_key_exists('day_of_week', $entry)) {
+                    $entry['day_of_week'] = $this->normalizeDayIdentifier($entry['day_of_week']);
+                } elseif (array_key_exists('day', $entry)) {
+                    $entry['day_of_week'] = $this->normalizeDayIdentifier($entry['day']);
+                    unset($entry['day']);
+                }
+
+                if (array_key_exists('opens_at', $entry)) {
+                    $entry['opens_at'] = $this->normalizeTimeString($entry['opens_at']);
+                }
+
+                if (array_key_exists('closes_at', $entry)) {
+                    $entry['closes_at'] = $this->normalizeTimeString($entry['closes_at']);
+                }
+
+                return $entry;
+            }, $input));
+        }
+
+        $normalized = [];
+
+        foreach ($input as $dayKey => $ranges) {
+            $day = $this->normalizeDayIdentifier($dayKey);
+
+            if ($day === null) {
+                $this->invalidBusinessHourKeys[] = (string) $dayKey;
+            }
+
+            if (! is_array($ranges) || $ranges === []) {
+                continue;
+            }
+
+            foreach ($ranges as $range) {
+                if (! is_array($range)) {
+                    $range = [];
+                }
+
+                if (! array_key_exists('day_of_week', $range)) {
+                    $range['day_of_week'] = $day;
+                }
+
+                if (array_key_exists('opens_at', $range)) {
+                    $range['opens_at'] = $this->normalizeTimeString($range['opens_at']);
+                }
+
+                if (array_key_exists('closes_at', $range)) {
+                    $range['closes_at'] = $this->normalizeTimeString($range['closes_at']);
+                }
+
+                $normalized[] = $range;
+            }
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeDayIdentifier(mixed $value): ?int
+    {
+        if (is_int($value) || ctype_digit((string) $value)) {
+            $intValue = (int) $value;
+
+            return $intValue >= 1 && $intValue <= 7 ? $intValue : null;
+        }
+
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = str_replace(['-', ' '], ['_', '_'], mb_strtolower(trim($value)));
+
+        $map = [
+            'monday' => 1,
+            'mon' => 1,
+            'lundi' => 1,
+            'tuesday' => 2,
+            'tue' => 2,
+            'tues' => 2,
+            'mardi' => 2,
+            'wednesday' => 3,
+            'wed' => 3,
+            'mercredi' => 3,
+            'thursday' => 4,
+            'thu' => 4,
+            'thur' => 4,
+            'thurs' => 4,
+            'jeudi' => 4,
+            'friday' => 5,
+            'fri' => 5,
+            'vendredi' => 5,
+            'saturday' => 6,
+            'sat' => 6,
+            'samedi' => 6,
+            'sunday' => 7,
+            'sun' => 7,
+            'dimanche' => 7,
+        ];
+
+        return $map[$normalized] ?? null;
+    }
+
+    private function normalizeTimeString(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $string = trim((string) $value);
+
+        if ($string === '') {
+            return null;
+        }
+
+        if (preg_match('/^(\d{1,2}):(\d{1,2})(?::\d{1,2})?$/', $string, $matches)) {
+            $hour = (int) $matches[1];
+            $minute = (int) $matches[2];
+
+            if ($hour < 0 || $hour > 23 || $minute < 0 || $minute > 59) {
+                return sprintf('%02d:%02d', $hour, $minute);
+            }
+
+            return sprintf('%02d:%02d', $hour, $minute);
+        }
+
+        return $string;
+    }
+
+    private function timeStringToMinutes(string $time): int
+    {
+        $parts = explode(':', $time);
+        $hour = (int) ($parts[0] ?? 0);
+        $minute = (int) ($parts[1] ?? 0);
+
+        return ($hour * 60) + $minute;
+    }
+}

--- a/app/Http/Requests/UpdateCompanyContactRequest.php
+++ b/app/Http/Requests/UpdateCompanyContactRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateCompanyContactRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $data = [];
+
+        foreach ([
+            'contact_name',
+            'contact_phone',
+            'address_line',
+            'postal_code',
+            'city',
+            'country',
+        ] as $field) {
+            if ($this->exists($field)) {
+                $data[$field] = $this->normalizeNullableString($this->input($field));
+            }
+        }
+
+        if ($this->exists('contact_email')) {
+            $email = trim((string) $this->input('contact_email'));
+            $data['contact_email'] = $email === '' ? null : mb_strtolower($email);
+        }
+
+        if ($data !== []) {
+            $this->merge($data);
+        }
+    }
+
+    public function rules(): array
+    {
+        return [
+            'contact_name' => 'sometimes|nullable|string|max:255',
+            'contact_email' => 'sometimes|nullable|email|max:255',
+            'contact_phone' => 'sometimes|nullable|string|max:64',
+            'address_line' => 'sometimes|nullable|string|max:255',
+            'postal_code' => 'sometimes|nullable|string|max:32',
+            'city' => 'sometimes|nullable|string|max:255',
+            'country' => 'sometimes|nullable|string|max:255',
+        ];
+    }
+
+    private function normalizeNullableString(mixed $value): ?string
+    {
+        $string = trim((string) $value);
+
+        return $string === '' ? null : $string;
+    }
+}

--- a/app/Http/Requests/UpdateCompanyImageRequest.php
+++ b/app/Http/Requests/UpdateCompanyImageRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateCompanyImageRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if ($this->has('image_url')) {
+            $this->merge([
+                'image_url' => trim((string) $this->input('image_url')),
+            ]);
+        }
+    }
+
+    public function rules(): array
+    {
+        return [
+            'image' => ['required_without:image_url', 'nullable', 'image', 'max:2048', 'mimes:jpeg,jpg,png,gif,webp,bmp,svg,heic'],
+            'image_url' => ['required_without:image', 'nullable', 'url'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'image.required_without' => "Veuillez fournir un fichier image ou une URL d'image.",
+            'image_url.required_without' => "Veuillez fournir un fichier image ou une URL d'image.",
+        ];
+    }
+}

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Str;
 
 /**
@@ -11,6 +12,15 @@ use Illuminate\Support\Str;
  * @property string $public_menu_card_url
  * @property bool $show_out_of_stock_menus_on_card
  * @property bool $show_menu_images
+ * @property string|null $logo_path
+ * @property string|null $contact_name
+ * @property string|null $contact_email
+ * @property string|null $contact_phone
+ * @property string|null $address_line
+ * @property string|null $postal_code
+ * @property string|null $city
+ * @property string|null $country
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\CompanyBusinessHour> $businessHours
  */
 class Company extends Model
 {
@@ -22,6 +32,14 @@ class Company extends Model
         'public_menu_card_url',
         'show_out_of_stock_menus_on_card',
         'show_menu_images',
+        'logo_path',
+        'contact_name',
+        'contact_email',
+        'contact_phone',
+        'address_line',
+        'postal_code',
+        'city',
+        'country',
     ];
 
     protected $casts = [
@@ -29,6 +47,14 @@ class Company extends Model
         'public_menu_card_url' => 'string',
         'show_out_of_stock_menus_on_card' => 'bool',
         'show_menu_images' => 'bool',
+        'logo_path' => 'string',
+        'contact_name' => 'string',
+        'contact_email' => 'string',
+        'contact_phone' => 'string',
+        'address_line' => 'string',
+        'postal_code' => 'string',
+        'city' => 'string',
+        'country' => 'string',
     ];
 
     protected $attributes = [
@@ -112,6 +138,14 @@ class Company extends Model
     public function quickAccesses()
     {
         return $this->hasMany(QuickAccess::class);
+    }
+
+    public function businessHours(): HasMany
+    {
+        return $this->hasMany(CompanyBusinessHour::class)
+            ->orderBy('day_of_week')
+            ->orderBy('sequence')
+            ->orderBy('opens_at');
     }
 
     // Removed: specialQuickAccess relation (merged into QuickAccess index 5)

--- a/app/Models/CompanyBusinessHour.php
+++ b/app/Models/CompanyBusinessHour.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $company_id
+ * @property int $day_of_week
+ * @property string $opens_at
+ * @property string $closes_at
+ * @property bool $is_overnight
+ * @property int $sequence
+ * @property-read \App\Models\Company $company
+ */
+class CompanyBusinessHour extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'company_id',
+        'day_of_week',
+        'opens_at',
+        'closes_at',
+        'is_overnight',
+        'sequence',
+    ];
+
+    protected $casts = [
+        'company_id' => 'int',
+        'day_of_week' => 'int',
+        'opens_at' => 'string',
+        'closes_at' => 'string',
+        'is_overnight' => 'bool',
+        'sequence' => 'int',
+    ];
+
+    public function company(): BelongsTo
+    {
+        return $this->belongsTo(Company::class);
+    }
+}

--- a/database/factories/CompanyBusinessHourFactory.php
+++ b/database/factories/CompanyBusinessHourFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\CompanyBusinessHour;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<CompanyBusinessHour>
+ */
+class CompanyBusinessHourFactory extends Factory
+{
+    protected $model = CompanyBusinessHour::class;
+
+    public function definition(): array
+    {
+        $day = $this->faker->numberBetween(1, 7);
+        $openHour = $this->faker->numberBetween(6, 20);
+        $openMinute = $this->faker->randomElement([0, 15, 30, 45]);
+        $duration = $this->faker->numberBetween(1, 6);
+        $closeHour = ($openHour + $duration) % 24;
+        $isOvernight = $openHour + $duration >= 24;
+
+        if (! $isOvernight && $closeHour === 0) {
+            $closeHour = 23;
+            $closeMinute = 59;
+        } else {
+            $closeMinute = $this->faker->randomElement([0, 15, 30, 45]);
+        }
+
+        $opensAt = sprintf('%02d:%02d', $openHour, $openMinute);
+        $closesAt = sprintf('%02d:%02d', $closeHour, $closeMinute);
+
+        if ($isOvernight && $closeHour === 0 && $closeMinute === 0) {
+            $closesAt = '00:00';
+        }
+
+        return [
+            'company_id' => null,
+            'day_of_week' => $day,
+            'opens_at' => $opensAt,
+            'closes_at' => $closesAt,
+            'is_overnight' => $isOvernight,
+            'sequence' => 1,
+        ];
+    }
+}

--- a/database/factories/CompanyFactory.php
+++ b/database/factories/CompanyFactory.php
@@ -21,6 +21,14 @@ class CompanyFactory extends Factory
             'open_food_facts_language' => 'fr',
             'show_out_of_stock_menus_on_card' => false,
             'show_menu_images' => true,
+            'logo_path' => null,
+            'contact_name' => $this->faker->name(),
+            'contact_email' => $this->faker->companyEmail(),
+            'contact_phone' => $this->faker->phoneNumber(),
+            'address_line' => $this->faker->streetAddress(),
+            'postal_code' => $this->faker->postcode(),
+            'city' => $this->faker->city(),
+            'country' => $this->faker->country(),
         ];
     }
 }

--- a/database/migrations/2025_10_10_000000_add_company_profile_fields_to_companies_table.php
+++ b/database/migrations/2025_10_10_000000_add_company_profile_fields_to_companies_table.php
@@ -1,0 +1,67 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('companies', function (Blueprint $table) {
+            if (! Schema::hasColumn('companies', 'logo_path')) {
+                $table->string('logo_path')->nullable()->after('show_menu_images');
+            }
+
+            if (! Schema::hasColumn('companies', 'contact_name')) {
+                $table->string('contact_name')->nullable()->after('logo_path');
+            }
+
+            if (! Schema::hasColumn('companies', 'contact_email')) {
+                $table->string('contact_email')->nullable()->after('contact_name');
+            }
+
+            if (! Schema::hasColumn('companies', 'contact_phone')) {
+                $table->string('contact_phone', 64)->nullable()->after('contact_email');
+            }
+
+            if (! Schema::hasColumn('companies', 'address_line')) {
+                $table->string('address_line')->nullable()->after('contact_phone');
+            }
+
+            if (! Schema::hasColumn('companies', 'postal_code')) {
+                $table->string('postal_code', 32)->nullable()->after('address_line');
+            }
+
+            if (! Schema::hasColumn('companies', 'city')) {
+                $table->string('city')->nullable()->after('postal_code');
+            }
+
+            if (! Schema::hasColumn('companies', 'country')) {
+                $table->string('country')->nullable()->after('city');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        $columns = [
+            'logo_path',
+            'contact_name',
+            'contact_email',
+            'contact_phone',
+            'address_line',
+            'postal_code',
+            'city',
+            'country',
+        ];
+
+        $existing = array_values(array_filter($columns, fn ($column) => Schema::hasColumn('companies', $column)));
+
+        if ($existing !== []) {
+            Schema::table('companies', function (Blueprint $table) use ($existing) {
+                $table->dropColumn($existing);
+            });
+        }
+    }
+};

--- a/database/migrations/2025_10_10_000100_create_company_business_hours_table.php
+++ b/database/migrations/2025_10_10_000100_create_company_business_hours_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('company_business_hours')) {
+            Schema::create('company_business_hours', function (Blueprint $table) {
+                $table->id()->comment('Identifiant technique unique d\'un créneau horaire.');
+                $table->foreignId('company_id')
+                    ->constrained()
+                    ->cascadeOnDelete()
+                    ->comment('Lien vers la compagnie propriétaire de ce créneau; supprimé automatiquement si la compagnie disparaît.');
+                $table->unsignedTinyInteger('day_of_week')
+                    ->comment('Jour ISO-8601 (1=lundi ... 7=dimanche) auquel appartient le créneau dans l\'agenda du restaurant.');
+                $table->time('opens_at')
+                    ->comment('Heure locale d\'ouverture du service (format HH:MM) pour ce créneau spécifique.');
+                $table->time('closes_at')
+                    ->comment('Heure locale de fermeture du service. Si elle est inférieure à opens_at, le flag is_overnight doit être activé.');
+                $table->boolean('is_overnight')
+                    ->default(false)
+                    ->comment('Indique qu\'un service traverse minuit et se termine le jour suivant, conservant ainsi la continuité métier.');
+                $table->unsignedTinyInteger('sequence')
+                    ->default(0)
+                    ->comment('Ordre d\'affichage normalisé des créneaux d\'une même journée (0 pour le premier, 1 pour le second, etc.).');
+                $table->timestamp('created_at')->nullable()->comment('Date d\'enregistrement du créneau pour le suivi et l\'audit.');
+                $table->timestamp('updated_at')->nullable()->comment('Date de dernière modification du créneau pour refléter les ajustements d\'horaires.');
+
+                $table->unique(['company_id', 'day_of_week', 'opens_at', 'closes_at'], 'company_hours_unique_interval');
+                $table->index(['company_id', 'day_of_week', 'sequence'], 'company_hours_day_sequence_index');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('company_business_hours');
+    }
+};

--- a/database/seeders/CompanySeeder.php
+++ b/database/seeders/CompanySeeder.php
@@ -12,8 +12,55 @@ class CompanySeeder extends Seeder
      */
     public function run(): void
     {
-        Company::factory()->create(['name' => 'GoofyTeam']);
-        Company::factory()->create(['name' => 'Charlie Kirk']);
-        Company::factory()->count(8)->create();
+        $companies = [
+            Company::factory()->create(['name' => 'GoofyTeam']),
+            Company::factory()->create(['name' => 'Charlie Kirk']),
+        ];
+
+        foreach (Company::factory()->count(8)->create() as $company) {
+            $companies[] = $company;
+        }
+
+        foreach ($companies as $company) {
+            $this->seedBusinessHours($company);
+        }
+    }
+
+    private function seedBusinessHours(Company $company): void
+    {
+        $company->businessHours()->delete();
+
+        $standardService = [
+            ['opens_at' => '11:30:00', 'closes_at' => '14:30:00', 'is_overnight' => false],
+            ['opens_at' => '18:30:00', 'closes_at' => '22:30:00', 'is_overnight' => false],
+        ];
+
+        $weekendService = [
+            ['opens_at' => '11:30:00', 'closes_at' => '15:00:00', 'is_overnight' => false],
+            ['opens_at' => '18:30:00', 'closes_at' => '02:00:00', 'is_overnight' => true],
+        ];
+
+        $records = [];
+
+        foreach (range(1, 7) as $day) {
+            $slots = in_array($day, [6, 7], true) ? $weekendService : $standardService;
+            $sequence = 1;
+
+            foreach ($slots as $slot) {
+                $records[] = [
+                    'day_of_week' => $day,
+                    'opens_at' => $slot['opens_at'],
+                    'closes_at' => $slot['closes_at'],
+                    'is_overnight' => $slot['is_overnight'] || $slot['closes_at'] <= $slot['opens_at'],
+                    'sequence' => $sequence++,
+                ];
+            }
+        }
+
+        if ($records === []) {
+            return;
+        }
+
+        $company->businessHours()->createMany($records);
     }
 }

--- a/graphql/models/company.graphql
+++ b/graphql/models/company.graphql
@@ -21,10 +21,48 @@ type Company {
     "Paramètres visibles publiquement pour la carte des menus."
     public_menu_settings: PublicMenuSettings!
 
+    "Logo ou image de présentation de l'entreprise."
+    logo_path: String
+
+    "Nom de la personne à contacter."
+    contact_name: String
+
+    "Adresse e-mail de contact."
+    contact_email: String
+
+    "Numéro de téléphone principal."
+    contact_phone: String
+
+    "Ligne d'adresse principale."
+    address_line: String
+
+    "Code postal."
+    postal_code: String
+
+    "Ville."
+    city: String
+
+    "Pays."
+    country: String
+
+    "Horaires d'ouverture de la semaine."
+    businessHours: [CompanyBusinessHour!]! @hasMany
+
     "When the company was created."
     created_at: DateTime!
 
     "When the company was last updated."
+    updated_at: DateTime!
+}
+
+type CompanyBusinessHour {
+    id: ID!
+    day_of_week: Int!
+    opens_at: String!
+    closes_at: String!
+    is_overnight: Boolean!
+    sequence: Int!
+    created_at: DateTime!
     updated_at: DateTime!
 }
 

--- a/routes/authed_route.php
+++ b/routes/authed_route.php
@@ -37,6 +37,9 @@ Route::prefix('user')->name('user.')->group(function () {
 // Groupe de routes pour l'entreprise
 Route::prefix('company')->name('company.')->group(function () {
     Route::put('/options', [CompanyController::class, 'updateOptions'])->name('options.update');
+    Route::put('/contact', [CompanyController::class, 'updateContact'])->name('contact.update');
+    Route::put('/business-hours', [CompanyController::class, 'updateBusinessHours'])->name('business-hours.update');
+    Route::post('/logo', [CompanyController::class, 'updateLogo'])->name('logo.update');
 });
 
 Route::put('/public-menus', [CompanyController::class, 'updateOptions'])->name('public-menus.update');

--- a/tests/Feature/CompanyControllerTest.php
+++ b/tests/Feature/CompanyControllerTest.php
@@ -3,8 +3,13 @@
 namespace Tests\Feature;
 
 use App\Models\Company;
+use App\Models\CompanyBusinessHour;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
@@ -31,7 +36,8 @@ class CompanyControllerTest extends TestCase
 
         $response
             ->assertStatus(200)
-            ->assertJsonPath('data.open_food_facts_language', 'en');
+            ->assertJsonPath('data.open_food_facts_language', 'en')
+            ->assertJsonPath('data.business_hours', []);
 
         $company->refresh();
 
@@ -42,5 +48,428 @@ class CompanyControllerTest extends TestCase
         );
         $this->assertFalse($company->show_out_of_stock_menus_on_card);
         $this->assertTrue($company->show_menu_images);
+    }
+
+    public function test_update_contact_information(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+
+        $payload = [
+            'contact_name' => 'Chef Gaston',
+            'contact_email' => 'contact@example.com',
+            'contact_phone' => '+33 1 23 45 67 89',
+            'address_line' => '12 rue des Oliviers',
+            'postal_code' => '75001',
+            'city' => 'Paris',
+            'country' => 'France',
+        ];
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/company/contact', $payload)
+            ->assertStatus(200);
+
+        foreach ($payload as $key => $value) {
+            $response->assertJsonPath("data.{$key}", $value);
+        }
+
+        $company->refresh();
+
+        foreach ($payload as $key => $value) {
+            $this->assertSame($value, $company->getAttribute($key));
+        }
+    }
+
+    public function test_update_contact_information_can_clear_fields_and_normalizes_email(): void
+    {
+        $company = Company::factory()->create([
+            'contact_name' => 'Chef Initial',
+            'contact_email' => 'initial@example.com',
+            'contact_phone' => '+33 1 98 76 54 32',
+            'address_line' => '10 rue de la Paix',
+        ]);
+        $user = User::factory()->create(['company_id' => $company->id]);
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/company/contact', [
+                'contact_name' => '  Chef Marie  ',
+                'contact_email' => 'CONTACT@EXAMPLE.COM ',
+                'contact_phone' => '   ',
+                'address_line' => '',
+            ])
+            ->assertStatus(200);
+
+        $response->assertJsonPath('data.contact_name', 'Chef Marie');
+        $response->assertJsonPath('data.contact_email', 'contact@example.com');
+        $response->assertJsonPath('data.contact_phone', null);
+        $response->assertJsonPath('data.address_line', null);
+
+        $company->refresh();
+
+        $this->assertSame('Chef Marie', $company->contact_name);
+        $this->assertSame('contact@example.com', $company->contact_email);
+        $this->assertNull($company->contact_phone);
+        $this->assertNull($company->address_line);
+    }
+
+    public function test_update_business_hours(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+
+        $payload = [
+            'business_hours' => [
+                ['day_of_week' => 1, 'opens_at' => '09:00', 'closes_at' => '12:00'],
+                ['day_of_week' => 1, 'opens_at' => '18:00', 'closes_at' => '02:00', 'is_overnight' => true],
+                ['day_of_week' => 6, 'opens_at' => '10:30', 'closes_at' => '15:00'],
+            ],
+        ];
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/company/business-hours', $payload)
+            ->assertStatus(200)
+            ->json('data.business_hours');
+
+        $this->assertCount(3, $response);
+        $this->assertSame([1, 1, 6], Arr::pluck($response, 'day_of_week'));
+        $this->assertSame(['09:00', '18:00', '10:30'], Arr::pluck($response, 'opens_at'));
+        $this->assertSame([false, true, false], Arr::pluck($response, 'is_overnight'));
+
+        $hours = CompanyBusinessHour::query()
+            ->where('company_id', $company->id)
+            ->orderBy('day_of_week')
+            ->orderBy('sequence')
+            ->get();
+
+        $this->assertCount(3, $hours);
+        $this->assertSame('09:00:00', $hours[0]->opens_at);
+        $this->assertSame('12:00:00', $hours[0]->closes_at);
+        $this->assertFalse($hours[0]->is_overnight);
+        $this->assertSame(1, $hours[0]->sequence);
+
+        $this->assertSame('18:00:00', $hours[1]->opens_at);
+        $this->assertSame('02:00:00', $hours[1]->closes_at);
+        $this->assertTrue($hours[1]->is_overnight);
+        $this->assertSame(2, $hours[1]->sequence);
+    }
+
+    public function test_update_business_hours_supports_day_name_payload(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+
+        $payload = [
+            'business_hours' => [
+                'monday' => [
+                    ['opens_at' => '08:00', 'closes_at' => '12:00'],
+                ],
+                'dimanche' => [
+                    ['opens_at' => '18:00', 'closes_at' => '01:00', 'is_overnight' => true],
+                ],
+            ],
+        ];
+
+        $this->actingAs($user)
+            ->putJson('/api/company/business-hours', $payload)
+            ->assertStatus(200)
+            ->assertJsonPath('data.business_hours.0.day_of_week', 1)
+            ->assertJsonPath('data.business_hours.1.day_of_week', 7);
+
+        $hours = CompanyBusinessHour::query()
+            ->where('company_id', $company->id)
+            ->orderBy('day_of_week')
+            ->get();
+
+        $this->assertCount(2, $hours);
+        $this->assertSame(1, $hours[0]->day_of_week);
+        $this->assertSame(7, $hours[1]->day_of_week);
+    }
+
+    public function test_update_business_hours_orders_slots_and_resets_sequence_per_day(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+
+        $payload = [
+            'business_hours' => [
+                ['day_of_week' => 4, 'opens_at' => '18:30', 'closes_at' => '23:00'],
+                ['day_of_week' => 4, 'opens_at' => '11:30', 'closes_at' => '14:30'],
+                ['day_of_week' => 5, 'opens_at' => '09:00', 'closes_at' => '12:00'],
+            ],
+        ];
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/company/business-hours', $payload)
+            ->assertStatus(200)
+            ->json('data.business_hours');
+
+        $this->assertSame([4, 4, 5], Arr::pluck($response, 'day_of_week'));
+        $this->assertSame(['11:30', '18:30', '09:00'], Arr::pluck($response, 'opens_at'));
+        $this->assertSame([1, 2, 1], Arr::pluck($response, 'sequence'));
+
+        $company->refresh();
+
+        $grouped = $company->businessHours
+            ->groupBy('day_of_week')
+            ->map(fn ($collection) => $collection->values());
+
+        $thursday = $grouped->get(4);
+        $friday = $grouped->get(5);
+
+        $this->assertNotNull($thursday);
+        $this->assertNotNull($friday);
+
+        $this->assertSame(['11:30:00', '18:30:00'], $thursday->pluck('opens_at')->all());
+        $this->assertSame([1, 2], $thursday->pluck('sequence')->all());
+        $this->assertSame(['09:00:00'], $friday->pluck('opens_at')->all());
+        $this->assertSame([1], $friday->pluck('sequence')->all());
+    }
+
+    public function test_update_business_hours_replaces_previous_entries(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+
+        CompanyBusinessHour::factory()->for($company)->create([
+            'day_of_week' => 1,
+            'opens_at' => '09:00',
+            'closes_at' => '12:00',
+            'sequence' => 1,
+        ]);
+
+        CompanyBusinessHour::factory()->for($company)->create([
+            'day_of_week' => 2,
+            'opens_at' => '14:00',
+            'closes_at' => '18:00',
+            'sequence' => 1,
+        ]);
+
+        $payload = [
+            'business_hours' => [
+                ['day_of_week' => 3, 'opens_at' => '10:00', 'closes_at' => '16:00'],
+            ],
+        ];
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/company/business-hours', $payload)
+            ->assertStatus(200)
+            ->json('data.business_hours');
+
+        $this->assertCount(1, $response);
+        $this->assertSame(3, $response[0]['day_of_week']);
+        $this->assertSame('10:00', $response[0]['opens_at']);
+
+        $this->assertDatabaseCount('company_business_hours', 1);
+
+        $hour = CompanyBusinessHour::query()->first();
+        $this->assertNotNull($hour);
+        $this->assertSame(3, $hour->day_of_week);
+        $this->assertSame('10:00:00', $hour->opens_at);
+        $this->assertSame('16:00:00', $hour->closes_at);
+        $this->assertSame(1, $hour->sequence);
+    }
+
+    public function test_update_business_hours_clears_existing_entries_with_empty_payload(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+
+        CompanyBusinessHour::factory()->for($company)->create([
+            'day_of_week' => 6,
+            'opens_at' => '19:00',
+            'closes_at' => '23:00',
+        ]);
+
+        $this->actingAs($user)
+            ->putJson('/api/company/business-hours', ['business_hours' => []])
+            ->assertStatus(200)
+            ->assertJsonPath('data.business_hours', []);
+
+        $this->assertDatabaseCount('company_business_hours', 0);
+    }
+
+    public function test_update_business_hours_rejects_overlapping_intervals(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+
+        $this->actingAs($user)
+            ->putJson('/api/company/business-hours', [
+                'business_hours' => [
+                    ['day_of_week' => 2, 'opens_at' => '09:00', 'closes_at' => '12:00'],
+                    ['day_of_week' => 2, 'opens_at' => '11:00', 'closes_at' => '14:00'],
+                ],
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['business_hours.1.opens_at']);
+    }
+
+    public function test_update_business_hours_rejects_wraparound_overlap(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+
+        $this->actingAs($user)
+            ->putJson('/api/company/business-hours', [
+                'business_hours' => [
+                    ['day_of_week' => 7, 'opens_at' => '18:00', 'closes_at' => '02:00', 'is_overnight' => true],
+                    ['day_of_week' => 1, 'opens_at' => '01:00', 'closes_at' => '05:00'],
+                ],
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['business_hours.1.opens_at']);
+    }
+
+    public function test_update_business_hours_rejects_close_before_open_without_overnight_flag(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+
+        $this->actingAs($user)
+            ->putJson('/api/company/business-hours', [
+                'business_hours' => [
+                    ['day_of_week' => 5, 'opens_at' => '18:00', 'closes_at' => '02:00'],
+                ],
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['business_hours.0.closes_at']);
+    }
+
+    public function test_update_business_hours_rejects_identical_open_and_close_times(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+
+        $this->actingAs($user)
+            ->putJson('/api/company/business-hours', [
+                'business_hours' => [
+                    ['day_of_week' => 3, 'opens_at' => '10:00', 'closes_at' => '10:00'],
+                ],
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['business_hours.0.closes_at']);
+    }
+
+    public function test_update_business_hours_rejects_invalid_day_key(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+
+        $this->actingAs($user)
+            ->putJson('/api/company/business-hours', [
+                'business_hours' => [
+                    'funday' => [
+                        ['opens_at' => '09:00', 'closes_at' => '17:00'],
+                    ],
+                ],
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['business_hours']);
+    }
+
+    public function test_update_business_hours_rejects_invalid_time(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+
+        $this->actingAs($user)
+            ->putJson('/api/company/business-hours', [
+                'business_hours' => [
+                    ['day_of_week' => 3, 'opens_at' => 'invalid', 'closes_at' => '17:00'],
+                ],
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['business_hours.0.opens_at']);
+    }
+
+    public function test_upload_company_logo_requires_file_or_url(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+
+        $this->actingAs($user)
+            ->postJson('/api/company/logo', [])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['image', 'image_url']);
+    }
+
+    public function test_upload_company_logo_with_file(): void
+    {
+        Storage::fake('s3');
+
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+
+        $file = UploadedFile::fake()->image('logo.jpg', 300, 300);
+
+        $response = $this->actingAs($user)
+            ->postJson('/api/company/logo', [
+                'image' => $file,
+            ])
+            ->assertStatus(200)
+            ->json('data.logo_path');
+
+        $this->assertNotNull($response);
+        $this->assertStringStartsWith('companies/', $response);
+        $this->assertTrue(Storage::disk('s3')->exists($response));
+
+        $company->refresh();
+        $this->assertSame($response, $company->logo_path);
+    }
+
+    public function test_upload_company_logo_with_url(): void
+    {
+        Storage::fake('s3');
+
+        $imageBytes = random_bytes(1024);
+
+        Http::fake([
+            'example.com/*' => Http::response($imageBytes, 200, [
+                'Content-Type' => 'image/png',
+                'Content-Length' => strlen($imageBytes),
+            ]),
+        ]);
+
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['company_id' => $company->id]);
+
+        $response = $this->actingAs($user)
+            ->postJson('/api/company/logo', [
+                'image_url' => 'https://example.com/logo.png',
+            ])
+            ->assertStatus(200)
+            ->json('data.logo_path');
+
+        $this->assertNotNull($response);
+        $this->assertTrue(Storage::disk('s3')->exists($response));
+
+        $company->refresh();
+        $this->assertSame($response, $company->logo_path);
+    }
+
+    public function test_upload_company_logo_replaces_previous_file(): void
+    {
+        Storage::fake('s3');
+
+        $company = Company::factory()->create(['logo_path' => 'companies/old-logo.png']);
+        Storage::disk('s3')->put('companies/old-logo.png', 'old');
+
+        $user = User::factory()->create(['company_id' => $company->id]);
+
+        $newFile = UploadedFile::fake()->image('new-logo.png');
+
+        $newPath = $this->actingAs($user)
+            ->postJson('/api/company/logo', [
+                'image' => $newFile,
+            ])
+            ->assertStatus(200)
+            ->json('data.logo_path');
+
+        $this->assertNotNull($newPath);
+        $this->assertTrue(Storage::disk('s3')->exists($newPath));
+        $this->assertFalse(Storage::disk('s3')->exists('companies/old-logo.png'));
+
+        $company->refresh();
+        $this->assertSame($newPath, $company->logo_path);
     }
 }


### PR DESCRIPTION
## Summary
- allow company business hours payloads to be empty so schedules can be cleared and reused in validation
- seed deterministic weekly service slots plus contact details for demo and default companies so fixtures expose the new settings
- extend company settings feature tests to cover contact normalization, schedule sequencing/overwrites, validation edge cases, and logo upload requirements

## Testing
- `./vendor/bin/pint`
- `./vendor/bin/phpstan analyse`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68d0893c019c832d91b61fbf3a78e444