### PR TITLE
Add bulk ingredient quantity update endpoint

### DIFF
--- a/routes/authed_route.php
+++ b/routes/authed_route.php
@@ -60,6 +60,7 @@ Route::prefix('preparations')->name('preparations.')->group(function () {
 // Groupe de routes pour les ingrédients
 Route::prefix('ingredients')->name('ingredients.')->group(function () {
     Route::post('/bulk', [IngredientController::class, 'bulkStore'])->name('bulk-store');
+    Route::put('/bulk/quantities', [IngredientController::class, 'bulkUpdateQuantities'])->name('bulk-update-quantities');
     Route::post('/', [IngredientController::class, 'store'])->name('store');
     Route::put('/{ingredient}', [IngredientController::class, 'update'])->name('update');
     Route::put('/{ingredient}/threshold', [IngredientController::class, 'updateThreshold'])->name('update-threshold');


### PR DESCRIPTION
## Summary
- add a dedicated `bulkUpdateQuantities` endpoint on the ingredient controller to validate and adjust stock levels for several ingredients at once
- register the new PUT `/api/ingredients/bulk/quantities` route
- cover the new behaviour and validation rules with feature tests

## Testing
- php artisan test --filter=IngredientControllerTest
- vendor/bin/pint
- vendor/bin/phpstan analyse --memory-limit=2G

------
https://chatgpt.com/codex/tasks/task_e_68d1d11b99b0832d9d336d3a3e52586e