### PR TITLE
feat: proxy company logo via GraphQL resolver

### DIFF
--- a/app/GraphQL/Resolvers/CompanyResolver.php
+++ b/app/GraphQL/Resolvers/CompanyResolver.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\GraphQL\Resolvers;
+
+use App\Models\Company;
+
+class CompanyResolver
+{
+    public function logoPath(Company $company): ?string
+    {
+        if (! $company->logo_path) {
+            return null;
+        }
+
+        return url('/api/image-proxy/'.$company->logo_path);
+    }
+}

--- a/graphql/models/company.graphql
+++ b/graphql/models/company.graphql
@@ -23,6 +23,7 @@ type Company {
 
     "Logo ou image de présentation de l'entreprise."
     logo_path: String
+        @field(resolver: "App\\GraphQL\\Resolvers\\CompanyResolver@logoPath")
 
     "Nom de la personne à contacter."
     contact_name: String

--- a/tests/Feature/CompanyQueryTest.php
+++ b/tests/Feature/CompanyQueryTest.php
@@ -88,7 +88,7 @@ class CompanyQueryTest extends TestCase
         $response->assertJsonPath('data.company.public_menu_settings.public_menu_card_url', 'share-card-demo');
         $response->assertJsonPath('data.company.public_menu_settings.show_out_of_stock_menus_on_card', true);
         $response->assertJsonPath('data.company.public_menu_settings.show_menu_images', false);
-        $response->assertJsonPath('data.company.logo_path', 'companies/demo.png');
+        $response->assertJsonPath('data.company.logo_path', url('/api/image-proxy/'.$company->logo_path));
         $response->assertJsonPath('data.company.contact_name', 'Chef Demo');
         $response->assertJsonPath('data.company.contact_email', 'contact@demo.test');
         $response->assertJsonPath('data.company.contact_phone', '+33 1 23 45 67 89');


### PR DESCRIPTION
## Summary
- add a dedicated CompanyResolver to expose proxied URLs for company logos
- update the GraphQL company schema to resolve logo paths through the proxy
- adjust the company query feature test to expect the proxied logo URL

## Testing
- ./vendor/bin/pint
- ./vendor/bin/phpstan analyse
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68d2a82374a0832db5b439d0f8b5514a