### PR TITLE
Use gustave seeder image as demo company logo

### DIFF
--- a/database/seeders/DemoSeeder.php
+++ b/database/seeders/DemoSeeder.php
@@ -91,6 +91,8 @@ class DemoSeeder extends Seeder
         ],
     ];
 
+    private const COMPANY_LOGO_PATH = 'private/seeders/images/gustave.png';
+
     private function seedAdditionalCompany(): void
     {
         $company = Company::updateOrCreate(
@@ -1714,7 +1716,11 @@ class DemoSeeder extends Seeder
             $company->fill($contact);
         }
 
-        if (! $company->logo_path) {
+        $logoPath = $this->publishSeederImage(self::COMPANY_LOGO_PATH);
+
+        if ($logoPath) {
+            $company->logo_path = $logoPath;
+        } elseif (! $company->logo_path) {
             $company->logo_path = $this->placeholderPath();
         }
 


### PR DESCRIPTION
## Summary
- add a dedicated constant for the Maison Gustave seeder logo image
- publish the gustave.png asset and assign it to the demo company before falling back to the placeholder

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d333b9bffc832da57ff3d494d54626