### PR TITLE
Include served orders in table resolver

### DIFF
--- a/app/GraphQL/Resolvers/TableResolver.php
+++ b/app/GraphQL/Resolvers/TableResolver.php
@@ -16,7 +16,10 @@ class TableResolver
     {
         /** @var Collection<int, Order> $orders */
         $orders = $table->orders()
-            ->where('status', OrderStatus::PENDING)
+            ->whereIn('status', [
+                OrderStatus::PENDING->value,
+                OrderStatus::SERVED->value,
+            ])
             ->latest('created_at')
             ->get();
 


### PR DESCRIPTION
## Summary
- include served orders when resolving table orders while still excluding payed and canceled records
- expand table order GraphQL tests to cover served orders and finalized order filtering

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d408fe9748832d996e38db12fb3506