### PR TITLE
Replace faker lorem ipsum notes in step menu seeder

### DIFF
--- a/database/seeders/StepMenuSeeder.php
+++ b/database/seeders/StepMenuSeeder.php
@@ -12,6 +12,14 @@ use Illuminate\Support\Arr;
 
 class StepMenuSeeder extends Seeder
 {
+    private const SAMPLE_NOTES = [
+        'Allergie : retirer les noisettes.',
+        'Cuisson demandée : saignant.',
+        'Servir la sauce à part.',
+        'Sans lactose : utiliser du lait végétal.',
+        'Ajouter une assiette bien chaude.',
+    ];
+
     /**
      * Run the database seeds.
      */
@@ -50,7 +58,7 @@ class StepMenuSeeder extends Seeder
                         'menu_id' => $menu->id,
                         'quantity' => random_int(1, 4),
                         'status' => $status,
-                        'note' => fake()->optional(0.3)->sentence(),
+                        'note' => $this->randomNote(),
                         'served_at' => $servedAt,
                     ]);
                 });
@@ -66,5 +74,14 @@ class StepMenuSeeder extends Seeder
         };
 
         return Arr::random($allowed);
+    }
+
+    private function randomNote(): ?string
+    {
+        if (random_int(1, 10) > 3) {
+            return null;
+        }
+
+        return Arr::random(self::SAMPLE_NOTES);
     }
 }


### PR DESCRIPTION
## Summary
- replace faker-generated sentences with curated French notes for seeded step menus
- add a helper to keep the same probability of adding a note without lorem ipsum text

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d422956df8832da996a4069e6be01a